### PR TITLE
fix(changeset): use correct package name lighthouse-plugin-ecoindex-core

### DIFF
--- a/.changeset/i18n-bp-runtime-strings.md
+++ b/.changeset/i18n-bp-runtime-strings.md
@@ -1,5 +1,5 @@
 ---
-"@cnumr/ecoindex-lh-plugin-ts": minor
+"lighthouse-plugin-ecoindex-core": minor
 ---
 
 i18n: migrate all bp audit runtime strings to Lighthouse native i18n system

--- a/.changeset/i18n-fr-locale-merge.md
+++ b/.changeset/i18n-fr-locale-merge.md
@@ -1,5 +1,5 @@
 ---
-"@cnumr/ecoindex-lh-plugin-ts": patch
+"lighthouse-plugin-ecoindex-core": patch
 ---
 
 fix(i18n): fix French locale registration and fr.json format

--- a/.changeset/i18n-table-helper-network-records.md
+++ b/.changeset/i18n-table-helper-network-records.md
@@ -1,5 +1,5 @@
 ---
-"@cnumr/ecoindex-lh-plugin-ts": minor
+"lighthouse-plugin-ecoindex-core": minor
 ---
 
 i18n: translate table-helper strings + add network resource table to requests/size audits


### PR DESCRIPTION
Three changeset files referenced `@cnumr/ecoindex-lh-plugin-ts` which does not exist in the workspace, causing the release workflow to fail with:

> Error: Found changeset i18n-bp-runtime-strings for package @cnumr/ecoindex-lh-plugin-ts which is not in the workspace

Fixed in all three files:
- `.changeset/i18n-bp-runtime-strings.md`
- `.changeset/i18n-fr-locale-merge.md`
- `.changeset/i18n-table-helper-network-records.md`

Correct package name: `lighthouse-plugin-ecoindex-core`