### PR TITLE
feat(bp): add details tables to 12 BP audits

### DIFF
--- a/.changeset/audit-details-tables.md
+++ b/.changeset/audit-details-tables.md
@@ -1,0 +1,5 @@
+---
+"lighthouse-plugin-ecoindex-core": patch
+---
+
+feat(bp): add details tables to 12 BP audits — now exposing domains, URLs, CSS selectors and code snippets alongside the score

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *grep*|*rg\\ *|*ripgrep*|*find\\ *|*fd\\ *|*ack\\ *|*ag\\ *)   [ -f graphify-out/graph.json ] &&   echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"graphify: Knowledge graph exists. Read graphify-out/GRAPH_REPORT.md for god nodes and community structure before searching raw files.\"}}'   || true ;; esac"
+          },
+          {
+            "type": "command",
+            "command": "CMD=$(python3 -c \"import json,sys; d=json.load(sys.stdin); print(d.get('tool_input',d).get('command',''))\" 2>/dev/null || true); case \"$CMD\" in *git\\ commit*) cd /Users/renaudheluin/DEV/DEV_GREENIT/ecoindex-lighthouse/lighthouse-plugin-ecoindex && pnpm format:check && pnpm typecheck && pnpm lint && pnpm typecheck:strict ;; esac"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ private-*
 
 # claude
 CLAUDE.md
-.claude
+!.claude/settings.json
 
 # graphify
 graphify-*

--- a/.superpowers/plans/2026-05-08-nouveaux-audits-greenit.md
+++ b/.superpowers/plans/2026-05-08-nouveaux-audits-greenit.md
@@ -1,0 +1,2079 @@
+# 18 nouveaux audits GreenIT (RWEB) — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implémenter 18 nouveaux audits RWEB + un script `generate-refs-urls.ts` dans `libs/ecoindex-lh-plugin-ts`.
+
+**Architecture:** Un gatherer `BPGatherer` collecte en une passe navigateur les métriques DOM qui ne sont pas dans `DOMInformations` (autoplay, serviceWorker, canvas, inline scripts/styles, animations). Les audits réseau utilisent `DevtoolsLog` + `NetworkRecords.request()`, les audits HTML utilisent `MainDocumentContent`. Tous les audits sont enregistrés dans `plugin.ts` avec `weight: 0`.
+
+**Tech Stack:** TypeScript, Lighthouse 13 (gatherers, computed artifacts), tsup (build), LHCI (tests).
+
+---
+
+## Carte des fichiers
+
+### Nouveaux fichiers
+| Fichier | Rôle |
+|---------|------|
+| `libs/ecoindex-lh-plugin-ts/src/gatherers/bp-gatherer.ts` | Collecte DOM en une passe navigateur |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0106-no-autoplay.ts` | Tier 1 — autoplay |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0059-no-social-sdk.ts` | Tier 1 — SDK sociaux |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0111-limit-analytics.ts` | Tier 1 — analytics |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0082-limit-domains.ts` | Tier 1 — domaines |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0112-no-redirects.ts` | Tier 1 — redirections |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0060-service-worker.ts` | Tier 1 — service worker |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0042-no-inline-assets.ts` | Tier 2 — inline CSS/JS |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0055-no-canvas.ts` | Tier 2 — canvas |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0032-limit-fonts.ts` | Tier 2 — polices externes |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0011-title-meta.ts` | Tier 2 — title + meta description |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0099-no-gif.ts` | Tier 3 — GIFs animés |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0009-no-animations.ts` | Tier 3 — animations CSS/JS |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0010-no-carousel.ts` | Tier 3 — carrousels |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0033-no-embedded-docs.ts` | Tier 3 — documents embarqués |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0039-css-containment.ts` | Tier 3 — CSS containment |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0084-hsts.ts` | Tier 3 — HSTS |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0081-no-cookie-on-static.ts` | Tier 3 — Cookie sur statiques |
+| `test/test-pages/bp-violations.html` | Page de test avec violations intentionnelles |
+| `scripts/generate-refs-urls.ts` | Script dev — régénère refs-urls.ts depuis API RWEB |
+
+### Fichiers modifiés
+| Fichier | Changement |
+|---------|------------|
+| `libs/ecoindex-lh-plugin-ts/src/types/index.d.ts` | Ajout `BPArtifacts` + `BPGathererResult` |
+| `libs/ecoindex-lh-plugin-ts/src/helpers/lhci/custom-config.ts` | Enregistrement `BPGatherer` dans `artifacts` |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/refs-urls.ts` | 18 nouvelles entrées RWEB |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/print-css.ts` | Mise à jour ID → `RWEB_0031`, URL → rweb.greenit.fr |
+| `libs/ecoindex-lh-plugin-ts/src/plugin.ts` | Enregistrement des 18 audits |
+| `test/test-pages/expected-results.json` | Ajout entrée `bp-violations` |
+| `test/test-pages/verify-results.js` | Support `expectedBPAudits` |
+| `test/test-ecoindex-lh-plugin-ts/.lighthouserc.cjs` | URL `bp-violations` |
+| `package.json` (racine) | Scripts `refs:update` |
+
+---
+
+## Task 1 — Types : BPArtifacts + BPGathererResult
+
+**Fichiers :**
+- Modifier : `libs/ecoindex-lh-plugin-ts/src/types/index.d.ts`
+
+- [ ] **Étape 1 : Ajouter les interfaces dans index.d.ts**
+
+Ouvrir `libs/ecoindex-lh-plugin-ts/src/types/index.d.ts` et ajouter à la fin, après l'interface `EcoindexResults` :
+
+```ts
+export interface BPArtifacts extends Artifacts {
+  BPGatherer: BPGathererResult
+}
+
+export interface BPGathererResult {
+  autoplaying: number
+  serviceWorkerActive: boolean
+  canvasCount: number
+  inlineScripts: number
+  inlineStyles: number
+  animatedElements: number
+}
+```
+
+- [ ] **Étape 2 : Vérifier le typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core typecheck
+```
+
+Attendu : pas d'erreur.
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/types/index.d.ts
+git commit -m "feat(types): add BPArtifacts and BPGathererResult interfaces"
+```
+
+---
+
+## Task 2 — BPGatherer
+
+**Fichiers :**
+- Créer : `libs/ecoindex-lh-plugin-ts/src/gatherers/bp-gatherer.ts`
+
+- [ ] **Étape 1 : Créer le fichier**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import { Gatherer } from 'lighthouse'
+
+class BPGatherer extends Gatherer {
+  meta: LH.Gatherer.GathererMeta = {
+    supportedModes: ['navigation', 'timespan', 'snapshot'],
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getArtifact(passContext: { driver: any }) {
+    const { driver } = passContext
+    const { executionContext } = driver
+
+    function collectBPData() {
+      if (typeof document === 'undefined') {
+        return {
+          autoplaying: 0,
+          serviceWorkerActive: false,
+          canvasCount: 0,
+          inlineScripts: 0,
+          inlineStyles: 0,
+          animatedElements: 0,
+        }
+      }
+
+      const autoplaying = document.querySelectorAll(
+        'video[autoplay], audio[autoplay], video[preload="auto"], audio[preload="auto"]',
+      ).length
+
+      const serviceWorkerActive = Boolean(
+        'serviceWorker' in navigator &&
+          navigator.serviceWorker &&
+          navigator.serviceWorker.controller,
+      )
+
+      const canvasCount = document.querySelectorAll('canvas').length
+
+      const inlineScripts = Array.from(
+        document.querySelectorAll('script:not([src])'),
+      ).filter(
+        s =>
+          s.getAttribute('type') !== 'application/ld+json' &&
+          (s.textContent || '').trim().length > 0,
+      ).length
+
+      const inlineStyles = Array.from(document.querySelectorAll('style')).filter(
+        s => (s.textContent || '').trim().length > 0,
+      ).length
+
+      let animatedElements = 0
+      const allElements = Array.from(document.querySelectorAll('*'))
+      for (const el of allElements) {
+        const cs = window.getComputedStyle(el)
+        const hasAnimation =
+          cs.animationName !== 'none' && cs.animationName !== ''
+        const hasTransition =
+          cs.transitionProperty !== 'none' &&
+          cs.transitionProperty !== '' &&
+          cs.transitionDuration !== '0s'
+        if (hasAnimation || hasTransition) animatedElements++
+      }
+
+      return {
+        autoplaying,
+        serviceWorkerActive,
+        canvasCount,
+        inlineScripts,
+        inlineStyles,
+        animatedElements,
+      }
+    }
+
+    const results = await executionContext.evaluate(collectBPData, { args: [] })
+    return results
+  }
+}
+
+export default BPGatherer
+```
+
+- [ ] **Étape 2 : Vérifier le typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core typecheck
+```
+
+Attendu : pas d'erreur.
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/gatherers/bp-gatherer.ts
+git commit -m "feat(gatherer): add BPGatherer for DOM-based BP metrics"
+```
+
+---
+
+## Task 3 — Enregistrer BPGatherer dans custom-config.ts
+
+**Fichiers :**
+- Modifier : `libs/ecoindex-lh-plugin-ts/src/helpers/lhci/custom-config.ts`
+
+- [ ] **Étape 1 : Ajouter l'import et l'artifact**
+
+Ouvrir `libs/ecoindex-lh-plugin-ts/src/helpers/lhci/custom-config.ts`.
+
+Ajouter l'import en tête de fichier (après l'import existant) :
+
+```ts
+import bpGatherer from '../../gatherers/bp-gatherer.js'
+```
+
+Ajouter dans le tableau `artifacts` (après l'entrée `DOMInformations`) :
+
+```ts
+{
+  id: 'BPGatherer',
+  gatherer: {
+    implementation: bpGatherer,
+  },
+},
+```
+
+Le fichier complet devient :
+
+```ts
+import bpGatherer from '../../gatherers/bp-gatherer.js'
+import domInformationsGatherer from '../../gatherers/dom-informations.js'
+
+/** @type {LH.Config} */
+export default {
+  extends: 'lighthouse:default',
+  settings: {
+    formFactor: 'desktop',
+    throttling: {
+      rttMs: 40,
+      throughputKbps: 10 * 1024,
+      cpuSlowdownMultiplier: 1,
+      requestLatencyMs: 0,
+      downloadThroughputKbps: 0,
+      uploadThroughputKbps: 0,
+    },
+    screenEmulation: {
+      mobile: false,
+      width: 1920,
+      height: 1080,
+    },
+    emulatedUserAgent: 'desktop',
+    maxWaitForLoad: 60 * 1000,
+    disableStorageReset: true,
+    preset: 'desktop',
+  },
+  plugins: ['lighthouse-plugin-ecoindex-core'],
+  artifacts: [
+    {
+      id: 'DOMInformations',
+      gatherer: {
+        implementation: domInformationsGatherer,
+      },
+    },
+    {
+      id: 'BPGatherer',
+      gatherer: {
+        implementation: bpGatherer,
+      },
+    },
+  ],
+}
+```
+
+- [ ] **Étape 2 : Build pour vérifier la résolution des imports**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core build
+```
+
+Attendu : build réussi, pas d'erreur TypeScript.
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/helpers/lhci/custom-config.ts
+git commit -m "feat(config): register BPGatherer in custom-config artifacts"
+```
+
+---
+
+## Task 4 — refs-urls.ts : 18 nouvelles entrées RWEB
+
+**Fichiers :**
+- Modifier : `libs/ecoindex-lh-plugin-ts/src/audits/bp/refs-urls.ts`
+
+> Ces URLs seront régénérées via `pnpm refs:update` (Task 14). Pour l'instant on les écrit en dur avec le pattern `rweb.greenit.fr`.
+
+- [ ] **Étape 1 : Remplacer le contenu de refs-urls.ts**
+
+```ts
+// Generated by scripts/generate-refs-urls.ts — update with: pnpm refs:update
+export default {
+  greenwebfoundation: {
+    home: {
+      fr: 'https://www.thegreenwebfoundation.org/',
+      en: 'https://www.thegreenwebfoundation.org/',
+    },
+    api_doc: {
+      fr: 'https://developers.thegreenwebfoundation.org/api/greencheck/v3/check-single-domain/',
+      en: 'https://developers.thegreenwebfoundation.org/api/greencheck/v3/check-single-domain/',
+    },
+  },
+  ecoindex: {
+    method: {
+      fr: 'https://www.ecoindex.fr/comment-ca-marche/#m%C3%A9thodologie-danalyse',
+      en: 'https://www.ecoindex.fr/comment-ca-marche/#m%C3%A9thodologie-danalyse',
+    },
+    grade: {
+      fr: 'https://www.ecoindex.fr/comment-ca-marche/#le-calcul-de-la-note',
+      en: 'https://www.ecoindex.fr/comment-ca-marche/#le-calcul-de-la-note',
+    },
+    score: {
+      fr: 'https://www.ecoindex.fr/comment-ca-marche/#le-calcul-de-lecoindex',
+      en: 'https://www.ecoindex.fr/comment-ca-marche/#le-calcul-de-lecoindex',
+    },
+    footprint: {
+      fr: 'https://www.ecoindex.fr/comment-ca-marche/#lempreinte-environnementale',
+      en: 'https://www.ecoindex.fr/comment-ca-marche/#lempreinte-environnementale',
+    },
+  },
+  rweb: {
+    // Legacy entries (kept for print-css.ts until Task 8)
+    bp_0027: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0027',
+      en: 'https://rweb.greenit.fr/en/fiches/0027',
+    },
+    bp_0101: {
+      fr: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_0101-ajouter-des-entetes-expires-ou-cache-control.html',
+      en: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_0101-ajouter-des-entetes-expires-ou-cache-control.html',
+    },
+    bp_0077: {
+      fr: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_0077-minifier-les-fichiers-css-javascript-html-et-svg.html',
+      en: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_0077-minifier-les-fichiers-css-javascript-html-et-svg.html',
+    },
+    bp_4006: {
+      fr: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_4006-privilegier-http2-a-http1.html',
+      en: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_4006-privilegier-http2-a-http1.html',
+    },
+    bp_0070: {
+      fr: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_0070-supprimer-tous-les-warnings-et-toutes-les-notices.html',
+      en: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_0070-supprimer-tous-les-warnings-et-toutes-les-notices.html',
+    },
+    bp_0095: {
+      fr: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_0095-eviter-les-redirections.html',
+      en: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_0095-eviter-les-redirections.html',
+    },
+    bp_0078: {
+      fr: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_0078-compresser-les-fichiers-css-javascript-html-et-svg.html',
+      en: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_0078-compresser-les-fichiers-css-javascript-html-et-svg.html',
+    },
+    bp_0041: {
+      fr: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_0041-ne-pas-faire-de-modification-du-dom-lorsquon-le-traverse.html',
+      en: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_0041-ne-pas-faire-de-modification-du-dom-lorsquon-le-traverse.html',
+    },
+    bp_0034: {
+      fr: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_0034-ne-pas-redimensionner-les-images-cote-navigateur.html',
+      en: 'https://ref.greenit.fr/rweb/fr/fiches/rweb_0034-ne-pas-redimensionner-les-images-cote-navigateur.html',
+    },
+    // Entrées générées — mettre à jour avec : pnpm refs:update
+    rweb_0031: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0031',
+      en: 'https://rweb.greenit.fr/en/fiches/0031',
+    },
+    rweb_0106: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0106',
+      en: 'https://rweb.greenit.fr/en/fiches/0106',
+    },
+    rweb_0059: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0059',
+      en: 'https://rweb.greenit.fr/en/fiches/0059',
+    },
+    rweb_0111: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0111',
+      en: 'https://rweb.greenit.fr/en/fiches/0111',
+    },
+    rweb_0082: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0082',
+      en: 'https://rweb.greenit.fr/en/fiches/0082',
+    },
+    rweb_0112: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0112',
+      en: 'https://rweb.greenit.fr/en/fiches/0112',
+    },
+    rweb_0060: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0060',
+      en: 'https://rweb.greenit.fr/en/fiches/0060',
+    },
+    rweb_0042: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0042',
+      en: 'https://rweb.greenit.fr/en/fiches/0042',
+    },
+    rweb_0055: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0055',
+      en: 'https://rweb.greenit.fr/en/fiches/0055',
+    },
+    rweb_0032: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0032',
+      en: 'https://rweb.greenit.fr/en/fiches/0032',
+    },
+    rweb_0011: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0011',
+      en: 'https://rweb.greenit.fr/en/fiches/0011',
+    },
+    rweb_0099: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0099',
+      en: 'https://rweb.greenit.fr/en/fiches/0099',
+    },
+    rweb_0009: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0009',
+      en: 'https://rweb.greenit.fr/en/fiches/0009',
+    },
+    rweb_0010: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0010',
+      en: 'https://rweb.greenit.fr/en/fiches/0010',
+    },
+    rweb_0033: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0033',
+      en: 'https://rweb.greenit.fr/en/fiches/0033',
+    },
+    rweb_0039: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0039',
+      en: 'https://rweb.greenit.fr/en/fiches/0039',
+    },
+    rweb_0084: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0084',
+      en: 'https://rweb.greenit.fr/en/fiches/0084',
+    },
+    rweb_0081: {
+      fr: 'https://rweb.greenit.fr/fr/fiches/0081',
+      en: 'https://rweb.greenit.fr/en/fiches/0081',
+    },
+  },
+}
+```
+
+- [ ] **Étape 2 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/refs-urls.ts
+git commit -m "feat(refs): add 18 RWEB entries in refs-urls.ts"
+```
+
+---
+
+## Task 5 — Audits Tier 1 réseau (DevtoolsLog)
+
+**Fichiers :**
+- Créer : `rweb-0059-no-social-sdk.ts`, `rweb-0111-limit-analytics.ts`, `rweb-0082-limit-domains.ts`, `rweb-0112-no-redirects.ts`
+
+> **Pattern commun** pour les 4 audits : import `NetworkRecords` depuis `lighthouse`, `static async audit()`, `requiredArtifacts: ['DevtoolsLog']`.
+
+- [ ] **Étape 1 : Créer `rweb-0059-no-social-sdk.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import { Audit, NetworkRecords } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+// platform.twitter.com reste actif après le rebranding X ; platform.x.com ajouté par précaution
+const SOCIAL_SDK_DOMAINS = [
+  'connect.facebook.net',
+  'platform.twitter.com',
+  'platform.x.com',
+  'platform.linkedin.com',
+  'apis.google.com',
+  'platform.instagram.com',
+]
+
+class BPRweb0059NoSocialSdk extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0059-no-social-sdk',
+      title: 'RWEB_0059 - No official social network buttons',
+      failureTitle: 'RWEB_0059 - Official social network SDK detected',
+      description: `Replace official social network buttons with static links to reduce third-party requests. [See RWEB_0059](${refsURLS.rweb.rweb_0059.en})`,
+      requiredArtifacts: ['DevtoolsLog'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static async audit(artifacts: LH.Artifacts, context: LH.Audit.Context) {
+    const records = await NetworkRecords.request(artifacts.DevtoolsLog, context)
+
+    const sdkRequests = records.filter(r =>
+      SOCIAL_SDK_DOMAINS.some(domain => r.url.includes(domain)),
+    )
+
+    return {
+      score: sdkRequests.length === 0 ? 1 : 0,
+      displayValue: `${sdkRequests.length} social SDK request(s) detected`,
+      numericValue: sdkRequests.length,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0059NoSocialSdk
+```
+
+- [ ] **Étape 2 : Créer `rweb-0111-limit-analytics.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import { Audit, NetworkRecords } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+const ANALYTICS_DOMAINS = [
+  'www.google-analytics.com',
+  'analytics.google.com',
+  'www.googletagmanager.com',
+  'script.hotjar.com',
+  'static.hotjar.com',
+  'cdn.matomo.cloud',
+  'cdn.mixpanel.com',
+  'api.segment.io',
+  'cdn.segment.com',
+  'cdn.amplitude.com',
+  'js.hs-analytics.net',
+  'js.hsforms.net',
+]
+
+class BPRweb0111LimitAnalytics extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0111-limit-analytics',
+      title: 'RWEB_0111 - Limit analytics tools (≤ 1)',
+      failureTitle: 'RWEB_0111 - Multiple analytics tools detected',
+      description: `Limit analytics tools to one per page. [See RWEB_0111](${refsURLS.rweb.rweb_0111.en})`,
+      requiredArtifacts: ['DevtoolsLog'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static async audit(artifacts: LH.Artifacts, context: LH.Audit.Context) {
+    const records = await NetworkRecords.request(artifacts.DevtoolsLog, context)
+
+    const matchedDomains = new Set<string>()
+    for (const record of records) {
+      for (const domain of ANALYTICS_DOMAINS) {
+        if (record.url.includes(domain)) {
+          matchedDomains.add(domain)
+        }
+      }
+    }
+
+    const count = matchedDomains.size
+
+    return {
+      score: count <= 1 ? 1 : 0,
+      displayValue: `${count} analytics tool(s) detected`,
+      numericValue: count,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0111LimitAnalytics
+```
+
+- [ ] **Étape 3 : Créer `rweb-0082-limit-domains.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import { Audit, NetworkRecords } from 'lighthouse'
+import { NetworkRequest } from 'lighthouse/core/lib/network-request.js'
+import refsURLS from './refs-urls.js'
+
+const MAX_DOMAINS = 5
+
+class BPRweb0082LimitDomains extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0082-limit-domains',
+      title: `RWEB_0082 - Limit resource domains (≤ ${MAX_DOMAINS})`,
+      failureTitle: `RWEB_0082 - Too many resource domains (> ${MAX_DOMAINS})`,
+      description: `Reduce the number of unique domains serving page resources. [See RWEB_0082](${refsURLS.rweb.rweb_0082.en})`,
+      requiredArtifacts: ['DevtoolsLog'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static async audit(artifacts: LH.Artifacts, context: LH.Audit.Context) {
+    const records = await NetworkRecords.request(artifacts.DevtoolsLog, context)
+
+    const domains = new Set<string>()
+    for (const record of records) {
+      if (NetworkRequest.isNonNetworkRequest(record)) continue
+      try {
+        const { hostname } = new URL(record.url)
+        domains.add(hostname)
+      } catch {
+        // ignore malformed URLs
+      }
+    }
+
+    const count = domains.size
+
+    return {
+      score: count <= MAX_DOMAINS ? 1 : 0,
+      displayValue: `${count} unique domain(s)`,
+      numericValue: count,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0082LimitDomains
+```
+
+- [ ] **Étape 4 : Créer `rweb-0112-no-redirects.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import { Audit, NetworkRecords } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+const REDIRECT_STATUSES = [301, 302, 307, 308]
+const MAX_REDIRECTS = 1
+
+class BPRweb0112NoRedirects extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0112-no-redirects',
+      title: `RWEB_0112 - Avoid HTTP redirects (≤ ${MAX_REDIRECTS})`,
+      failureTitle: `RWEB_0112 - Too many HTTP redirects (> ${MAX_REDIRECTS})`,
+      description: `Reduce HTTP redirects to avoid unnecessary round trips. [See RWEB_0112](${refsURLS.rweb.rweb_0112.en})`,
+      requiredArtifacts: ['DevtoolsLog'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static async audit(artifacts: LH.Artifacts, context: LH.Audit.Context) {
+    const records = await NetworkRecords.request(artifacts.DevtoolsLog, context)
+
+    const redirects = records.filter(r =>
+      REDIRECT_STATUSES.includes(r.statusCode),
+    )
+
+    return {
+      score: redirects.length <= MAX_REDIRECTS ? 1 : 0,
+      displayValue: `${redirects.length} redirect(s)`,
+      numericValue: redirects.length,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0112NoRedirects
+```
+
+- [ ] **Étape 5 : Typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core typecheck
+```
+
+Attendu : pas d'erreur.
+
+- [ ] **Étape 6 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0059-no-social-sdk.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0111-limit-analytics.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0082-limit-domains.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0112-no-redirects.ts
+git commit -m "feat(audits): add Tier 1 network audits (RWEB 0059, 0111, 0082, 0112)"
+```
+
+---
+
+## Task 6 — Audits Tier 1 BPGatherer
+
+**Fichiers :**
+- Créer : `rweb-0106-no-autoplay.ts`, `rweb-0060-service-worker.ts`
+
+> Ces audits utilisent `BPArtifacts`. L'artifact `BPGatherer` doit être enregistré dans `custom-config.ts` (Task 3) pour que les tests LHCI fonctionnent.
+
+- [ ] **Étape 1 : Créer `rweb-0106-no-autoplay.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import type { BPArtifacts } from '../../types/index.js'
+import { Audit } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+class BPRweb0106NoAutoplay extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0106-no-autoplay',
+      title: 'RWEB_0106 - No video/audio autoplay',
+      failureTitle: 'RWEB_0106 - Autoplay video/audio detected',
+      description: `Avoid autoplay on video and audio elements. [See RWEB_0106](${refsURLS.rweb.rweb_0106.en})`,
+      requiredArtifacts: ['BPGatherer'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static audit(artifacts: LH.Artifacts & BPArtifacts) {
+    const { autoplaying } = artifacts.BPGatherer
+
+    return {
+      score: autoplaying === 0 ? 1 : 0,
+      displayValue: `${autoplaying} autoplay element(s)`,
+      numericValue: autoplaying,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0106NoAutoplay
+```
+
+- [ ] **Étape 2 : Créer `rweb-0060-service-worker.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import type { BPArtifacts } from '../../types/index.js'
+import { Audit } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+class BPRweb0060ServiceWorker extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0060-service-worker',
+      title: 'RWEB_0060 - Service Worker active',
+      failureTitle: 'RWEB_0060 - No active Service Worker detected',
+      description: `A Service Worker improves caching and reduces network requests. [See RWEB_0060](${refsURLS.rweb.rweb_0060.en})`,
+      requiredArtifacts: ['BPGatherer'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static audit(artifacts: LH.Artifacts & BPArtifacts) {
+    const { serviceWorkerActive } = artifacts.BPGatherer
+
+    return {
+      score: serviceWorkerActive ? 1 : 0,
+      displayValue: serviceWorkerActive ? 'Service Worker active' : 'No Service Worker',
+      numericValue: serviceWorkerActive ? 1 : 0,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0060ServiceWorker
+```
+
+- [ ] **Étape 3 : Typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core typecheck
+```
+
+Attendu : pas d'erreur.
+
+- [ ] **Étape 4 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0106-no-autoplay.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0060-service-worker.ts
+git commit -m "feat(audits): add Tier 1 BPGatherer audits (RWEB 0106, 0060)"
+```
+
+---
+
+## Task 7 — Audits Tier 2 BPGatherer
+
+**Fichiers :**
+- Créer : `rweb-0042-no-inline-assets.ts`, `rweb-0055-no-canvas.ts`
+
+- [ ] **Étape 1 : Créer `rweb-0042-no-inline-assets.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import type { BPArtifacts } from '../../types/index.js'
+import { Audit } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+const MAX_INLINE_BLOCKS = 2
+
+class BPRweb0042NoInlineAssets extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0042-no-inline-assets',
+      title: `RWEB_0042 - Externalize CSS and JavaScript (≤ ${MAX_INLINE_BLOCKS} inline blocks)`,
+      failureTitle: `RWEB_0042 - Too many inline CSS/JS blocks (> ${MAX_INLINE_BLOCKS})`,
+      description: `Externalize CSS and JavaScript to improve caching. Inline <style> and <script> blocks reduce cache efficiency. [See RWEB_0042](${refsURLS.rweb.rweb_0042.en})`,
+      requiredArtifacts: ['BPGatherer'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static audit(artifacts: LH.Artifacts & BPArtifacts) {
+    const { inlineScripts, inlineStyles } = artifacts.BPGatherer
+    const total = inlineScripts + inlineStyles
+
+    return {
+      score: total <= MAX_INLINE_BLOCKS ? 1 : 0,
+      displayValue: `${total} inline block(s) (${inlineScripts} scripts, ${inlineStyles} styles)`,
+      numericValue: total,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0042NoInlineAssets
+```
+
+- [ ] **Étape 2 : Créer `rweb-0055-no-canvas.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import type { BPArtifacts } from '../../types/index.js'
+import { Audit } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+class BPRweb0055NoCanvas extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0055-no-canvas',
+      title: 'RWEB_0055 - No <canvas> element',
+      failureTitle: 'RWEB_0055 - <canvas> element(s) detected',
+      description: `Avoid <canvas> elements — they are CPU-intensive and prevent energy-efficient rendering. [See RWEB_0055](${refsURLS.rweb.rweb_0055.en})`,
+      requiredArtifacts: ['BPGatherer'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static audit(artifacts: LH.Artifacts & BPArtifacts) {
+    const { canvasCount } = artifacts.BPGatherer
+
+    return {
+      score: canvasCount === 0 ? 1 : 0,
+      displayValue: `${canvasCount} <canvas> element(s)`,
+      numericValue: canvasCount,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0055NoCanvas
+```
+
+- [ ] **Étape 3 : Typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core typecheck
+```
+
+- [ ] **Étape 4 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0042-no-inline-assets.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0055-no-canvas.ts
+git commit -m "feat(audits): add Tier 2 BPGatherer audits (RWEB 0042, 0055)"
+```
+
+---
+
+## Task 8 — Audits Tier 2 réseau/HTML + mise à jour print-css.ts
+
+**Fichiers :**
+- Créer : `rweb-0032-limit-fonts.ts`, `rweb-0011-title-meta.ts`
+- Modifier : `print-css.ts`
+
+- [ ] **Étape 1 : Créer `rweb-0032-limit-fonts.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import { Audit, NetworkRecords } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+const FONT_PROVIDER_DOMAINS = [
+  'fonts.googleapis.com',
+  'fonts.gstatic.com',
+  'use.typekit.net',
+  'p.typekit.net',
+  'fonts.bunny.net',
+  'fonts.adobe.com',
+  'cloud.typography.com',
+]
+
+const MAX_FONT_FAMILIES = 2
+
+class BPRweb0032LimitFonts extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0032-limit-fonts',
+      title: `RWEB_0032 - Prefer standard fonts (≤ ${MAX_FONT_FAMILIES} external families)`,
+      failureTitle: `RWEB_0032 - Too many external font families (> ${MAX_FONT_FAMILIES})`,
+      description: `Reduce external font requests by using system fonts or limiting to ${MAX_FONT_FAMILIES} external families. [See RWEB_0032](${refsURLS.rweb.rweb_0032.en})`,
+      requiredArtifacts: ['DevtoolsLog'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static async audit(artifacts: LH.Artifacts, context: LH.Audit.Context) {
+    const records = await NetworkRecords.request(artifacts.DevtoolsLog, context)
+
+    const matchedProviders = new Set<string>()
+    for (const record of records) {
+      for (const domain of FONT_PROVIDER_DOMAINS) {
+        if (record.url.includes(domain)) {
+          matchedProviders.add(domain)
+        }
+      }
+    }
+
+    const count = matchedProviders.size
+
+    return {
+      score: count <= MAX_FONT_FAMILIES ? 1 : 0,
+      displayValue: `${count} external font provider(s)`,
+      numericValue: count,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0032LimitFonts
+```
+
+- [ ] **Étape 2 : Créer `rweb-0011-title-meta.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import { Audit } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+class BPRweb0011TitleMeta extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0011-title-meta',
+      title: 'RWEB_0011 - Page title and meta description present',
+      failureTitle: 'RWEB_0011 - Missing <title> or <meta name="description">',
+      description: `Every page must have a non-empty <title> and a non-empty <meta name="description">. [See RWEB_0011](${refsURLS.rweb.rweb_0011.en})`,
+      requiredArtifacts: ['MainDocumentContent'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static audit(artifacts: LH.Artifacts) {
+    const html = artifacts.MainDocumentContent || ''
+
+    const titleMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i)
+    const hasTitle = !!(titleMatch && titleMatch[1].trim())
+
+    const metaMatch = html.match(
+      /<meta[^>]+name=["']description["'][^>]*content=["']([^"']+)["']/i,
+    ) || html.match(
+      /<meta[^>]+content=["']([^"']+)["'][^>]*name=["']description["']/i,
+    )
+    const hasDescription = !!(metaMatch && metaMatch[1].trim())
+
+    const score = hasTitle && hasDescription ? 1 : 0
+
+    const parts: string[] = []
+    if (!hasTitle) parts.push('missing <title>')
+    if (!hasDescription) parts.push('missing <meta name="description">')
+
+    return {
+      score,
+      displayValue: score === 1 ? 'Title and description present' : parts.join(', '),
+      numericValue: score,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0011TitleMeta
+```
+
+- [ ] **Étape 3 : Mettre à jour `print-css.ts`**
+
+Remplacer le contenu de `libs/ecoindex-lh-plugin-ts/src/audits/bp/print-css.ts` :
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import type { GathererArtifacts as IGathererArtifacts } from 'lighthouse'
+import { Audit } from 'lighthouse'
+import refsURLS from './../bp/refs-urls.js'
+
+class BPPrintCSS extends Audit {
+  static get meta() {
+    return {
+      id: 'bp-print-css',
+      title: 'RWEB_0031 - Print CSS',
+      failureTitle: 'RWEB_0031 - No print css implemented.',
+      description: `A print css must be implemented to hide useless elements when printing. [See RWEB_0031](${refsURLS.rweb.rweb_0031.en})`,
+      requiredArtifacts: ['LinkElements'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static audit(artifacts: LH.Artifacts) {
+    const stylesheets = artifacts.LinkElements.filter(
+      link =>
+        link.rel === 'stylesheet' && link?.node?.snippet.match(/media="print"/),
+    )
+    return {
+      score: stylesheets.length > 0 ? 1 : 0,
+      displayValue: `Print CSS count: ${stylesheets.length}`,
+      numericValue: stylesheets.length,
+      numericUnit: 'unitless' as
+        | 'unitless'
+        | 'byte'
+        | 'millisecond'
+        | 'element',
+    }
+  }
+}
+
+export default BPPrintCSS
+```
+
+> Note: l'import `IGathererArtifacts` est supprimé (non utilisé dans l'original), la référence `refsURLS.rweb.rweb_0031` remplace `refsURLS.rweb.bp_0027`.
+
+- [ ] **Étape 4 : Typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core typecheck
+```
+
+- [ ] **Étape 5 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0032-limit-fonts.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0011-title-meta.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/print-css.ts
+git commit -m "feat(audits): add Tier 2 audits (RWEB 0032, 0011) and update print-css to RWEB_0031"
+```
+
+---
+
+## Task 9 — Audits Tier 3 réseau
+
+**Fichiers :**
+- Créer : `rweb-0099-no-gif.ts`, `rweb-0010-no-carousel.ts`, `rweb-0039-css-containment.ts`, `rweb-0084-hsts.ts`, `rweb-0081-no-cookie-on-static.ts`
+
+- [ ] **Étape 1 : Créer `rweb-0099-no-gif.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import { Audit, NetworkRecords } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+class BPRweb0099NoGif extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0099-no-gif',
+      title: 'RWEB_0099 - No animated GIFs',
+      failureTitle: 'RWEB_0099 - Animated GIF(s) detected',
+      description: `Replace animated GIFs with video formats (mp4/webm) or CSS animations. [See RWEB_0099](${refsURLS.rweb.rweb_0099.en})`,
+      requiredArtifacts: ['DevtoolsLog', 'MainDocumentContent'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static async audit(artifacts: LH.Artifacts, context: LH.Audit.Context) {
+    const records = await NetworkRecords.request(artifacts.DevtoolsLog, context)
+
+    const networkGifs = records.filter(r => {
+      const url = r.url.toLowerCase()
+      return url.includes('.gif') && !url.includes('.gift')
+    })
+
+    const html = artifacts.MainDocumentContent || ''
+    const inlineGifMatches = html.match(/<img[^>]+src=["'][^"']*\.gif[^"']*["']/gi) || []
+    const inlineGifCount = inlineGifMatches.length
+
+    const total = networkGifs.length + inlineGifCount
+
+    return {
+      score: total === 0 ? 1 : 0,
+      displayValue: `${total} GIF(s) detected (${networkGifs.length} network, ${inlineGifCount} inline)`,
+      numericValue: total,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0099NoGif
+```
+
+- [ ] **Étape 2 : Créer `rweb-0010-no-carousel.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import { Audit, NetworkRecords } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+const CAROUSEL_PATTERNS = ['swiper', 'slick', 'owl.carousel', 'splide', 'glide', 'flickity', 'embla']
+
+class BPRweb0010NoCarousel extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0010-no-carousel',
+      title: 'RWEB_0010 - No carousel library',
+      failureTitle: 'RWEB_0010 - Carousel library detected',
+      description: `Carousels add JavaScript weight and harm accessibility. [See RWEB_0010](${refsURLS.rweb.rweb_0010.en})`,
+      requiredArtifacts: ['DevtoolsLog'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static async audit(artifacts: LH.Artifacts, context: LH.Audit.Context) {
+    const records = await NetworkRecords.request(artifacts.DevtoolsLog, context)
+
+    const matched = new Set<string>()
+    for (const record of records) {
+      const url = record.url.toLowerCase()
+      for (const pattern of CAROUSEL_PATTERNS) {
+        if (url.includes(pattern)) {
+          matched.add(pattern)
+        }
+      }
+    }
+
+    return {
+      score: matched.size === 0 ? 1 : 0,
+      displayValue: matched.size === 0
+        ? 'No carousel library detected'
+        : `Carousel detected: ${Array.from(matched).join(', ')}`,
+      numericValue: matched.size,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0010NoCarousel
+```
+
+- [ ] **Étape 3 : Créer `rweb-0039-css-containment.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import { Audit } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+class BPRweb0039CssContainment extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0039-css-containment',
+      title: 'RWEB_0039 - CSS containment used',
+      failureTitle: 'RWEB_0039 - CSS containment not detected',
+      description: `The CSS 'contain' property limits rendering scope and improves performance. [See RWEB_0039](${refsURLS.rweb.rweb_0039.en})`,
+      requiredArtifacts: ['Stylesheets'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static audit(artifacts: LH.Artifacts) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stylesheets: Array<{ content: string | null }> = (artifacts as any).Stylesheets || []
+
+    const hasContainment = stylesheets.some(
+      sheet => sheet.content && /\bcontain\s*:/.test(sheet.content),
+    )
+
+    return {
+      score: hasContainment ? 1 : 0,
+      displayValue: hasContainment ? 'CSS containment detected' : 'No CSS containment found',
+      numericValue: hasContainment ? 1 : 0,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0039CssContainment
+```
+
+- [ ] **Étape 4 : Créer `rweb-0084-hsts.ts`**
+
+> `responseHeaders` dans les NetworkRecords LH 13 est un objet `Record<string, string>`. La casse des noms de headers peut varier ; on normalise en minuscules.
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import { Audit, NetworkRecords } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+class BPRweb0084Hsts extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0084-hsts',
+      title: 'RWEB_0084 - HSTS header present',
+      failureTitle: 'RWEB_0084 - Missing Strict-Transport-Security header',
+      description: `The HSTS header forces HTTPS connections and prevents downgrade attacks. [See RWEB_0084](${refsURLS.rweb.rweb_0084.en})`,
+      requiredArtifacts: ['DevtoolsLog'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static async audit(artifacts: LH.Artifacts, context: LH.Audit.Context) {
+    const records = await NetworkRecords.request(artifacts.DevtoolsLog, context)
+
+    // Find the main HTML document response (first 200 HTML)
+    const mainDoc = records.find(
+      r => r.mimeType && r.mimeType.includes('text/html') && r.statusCode === 200,
+    )
+
+    if (!mainDoc || !mainDoc.responseHeaders) {
+      return {
+        score: 0,
+        displayValue: 'Main document not found',
+        numericValue: 0,
+        numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+      }
+    }
+
+    const headers: Record<string, string> = mainDoc.responseHeaders as unknown as Record<string, string>
+    const hstsValue = Object.entries(headers).find(
+      ([k]) => k.toLowerCase() === 'strict-transport-security',
+    )?.[1]
+
+    return {
+      score: hstsValue ? 1 : 0,
+      displayValue: hstsValue ? `HSTS: ${hstsValue}` : 'No HSTS header (expected on localhost)',
+      numericValue: hstsValue ? 1 : 0,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0084Hsts
+```
+
+- [ ] **Étape 5 : Créer `rweb-0081-no-cookie-on-static.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import { Audit, NetworkRecords } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+// Protocol.Network.ResourceType enum values (capitalized in LH 13)
+const STATIC_RESOURCE_TYPES = ['Image', 'Stylesheet', 'Script', 'Font', 'Media']
+
+class BPRweb0081NoCookieOnStatic extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0081-no-cookie-on-static',
+      title: 'RWEB_0081 - Static resources served without Cookie header',
+      failureTitle: 'RWEB_0081 - Static resources sent with Cookie header',
+      description: `Static resources (images, CSS, JS) should be served from cookie-free domains. [See RWEB_0081](${refsURLS.rweb.rweb_0081.en})`,
+      requiredArtifacts: ['DevtoolsLog'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static async audit(artifacts: LH.Artifacts, context: LH.Audit.Context) {
+    const records = await NetworkRecords.request(artifacts.DevtoolsLog, context)
+
+    const violations = records.filter(record => {
+      if (!STATIC_RESOURCE_TYPES.includes(record.resourceType as string)) return false
+
+      const reqHeaders: Record<string, string> = record.requestHeaders as unknown as Record<string, string>
+      if (!reqHeaders) return false
+
+      return Object.keys(reqHeaders).some(k => k.toLowerCase() === 'cookie')
+    })
+
+    return {
+      score: violations.length === 0 ? 1 : 0,
+      displayValue: `${violations.length} static resource(s) with Cookie header`,
+      numericValue: violations.length,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0081NoCookieOnStatic
+```
+
+- [ ] **Étape 6 : Typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core typecheck
+```
+
+- [ ] **Étape 7 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0099-no-gif.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0010-no-carousel.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0039-css-containment.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0084-hsts.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0081-no-cookie-on-static.ts
+git commit -m "feat(audits): add Tier 3 network audits (RWEB 0099, 0010, 0039, 0084, 0081)"
+```
+
+---
+
+## Task 10 — Audits Tier 3 HTML et BPGatherer
+
+**Fichiers :**
+- Créer : `rweb-0033-no-embedded-docs.ts`, `rweb-0009-no-animations.ts`
+
+- [ ] **Étape 1 : Créer `rweb-0033-no-embedded-docs.ts`**
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import { Audit } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+const DOCUMENT_EXTENSIONS = ['.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.odt', '.ods', '.odp']
+
+class BPRweb0033NoEmbeddedDocs extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0033-no-embedded-docs',
+      title: 'RWEB_0033 - No embedded documents',
+      failureTitle: 'RWEB_0033 - Embedded document(s) detected',
+      description: `Replace embedded documents (PDF, Office) with download links. [See RWEB_0033](${refsURLS.rweb.rweb_0033.en})`,
+      requiredArtifacts: ['MainDocumentContent'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static audit(artifacts: LH.Artifacts) {
+    const html = artifacts.MainDocumentContent || ''
+
+    // <embed src="..."> and <object data="...">
+    const embedMatches = html.match(/<embed[^>]+src=["'][^"']+["']/gi) || []
+    const objectMatches = html.match(/<object[^>]+data=["'][^"']+["']/gi) || []
+
+    // <iframe> pointing to a document extension
+    const iframeMatches = html.match(/<iframe[^>]+src=["'][^"']+["']/gi) || []
+    const iframeDocMatches = iframeMatches.filter(tag => {
+      const srcMatch = tag.match(/src=["']([^"']+)["']/)
+      if (!srcMatch) return false
+      const src = srcMatch[1].toLowerCase()
+      return DOCUMENT_EXTENSIONS.some(ext => src.includes(ext))
+    })
+
+    const docEmbeds = embedMatches.filter(tag => {
+      const srcMatch = tag.match(/src=["']([^"']+)["']/)
+      if (!srcMatch) return false
+      return DOCUMENT_EXTENSIONS.some(ext => srcMatch[1].toLowerCase().includes(ext))
+    })
+
+    const objectDocEmbeds = objectMatches.filter(tag => {
+      const dataMatch = tag.match(/data=["']([^"']+)["']/)
+      if (!dataMatch) return false
+      return DOCUMENT_EXTENSIONS.some(ext => dataMatch[1].toLowerCase().includes(ext))
+    })
+
+    const total = docEmbeds.length + objectDocEmbeds.length + iframeDocMatches.length
+
+    return {
+      score: total === 0 ? 1 : 0,
+      displayValue: `${total} embedded document(s)`,
+      numericValue: total,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0033NoEmbeddedDocs
+```
+
+- [ ] **Étape 2 : Créer `rweb-0009-no-animations.ts`**
+
+> `animatedElements` compte les éléments avec `animation-name !== none` ou `transition` active via `getComputedStyle`. Sur les pages sans CSS animé, la valeur est 0.
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import type { BPArtifacts } from '../../types/index.js'
+import { Audit } from 'lighthouse'
+import refsURLS from './refs-urls.js'
+
+class BPRweb0009NoAnimations extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-0009-no-animations',
+      title: 'RWEB_0009 - No CSS/JS animations',
+      failureTitle: 'RWEB_0009 - CSS/JS animations detected',
+      description: `Avoid CSS animations and transitions to reduce CPU usage and improve energy efficiency. [See RWEB_0009](${refsURLS.rweb.rweb_0009.en})`,
+      requiredArtifacts: ['BPGatherer'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static audit(artifacts: LH.Artifacts & BPArtifacts) {
+    const { animatedElements } = artifacts.BPGatherer
+
+    return {
+      score: animatedElements === 0 ? 1 : 0,
+      displayValue: `${animatedElements} animated element(s) detected`,
+      numericValue: animatedElements,
+      numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+    }
+  }
+}
+
+export default BPRweb0009NoAnimations
+```
+
+- [ ] **Étape 3 : Typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core typecheck
+```
+
+- [ ] **Étape 4 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0033-no-embedded-docs.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-0009-no-animations.ts
+git commit -m "feat(audits): add Tier 3 HTML/BPGatherer audits (RWEB 0033, 0009)"
+```
+
+---
+
+## Task 11 — Enregistrer les 18 audits dans plugin.ts
+
+**Fichiers :**
+- Modifier : `libs/ecoindex-lh-plugin-ts/src/plugin.ts`
+
+- [ ] **Étape 1 : Ajouter les 18 audits dans le tableau `audits`**
+
+Dans `plugin.ts`, ajouter après la ligne `{ path: '${__dirname}/audits/bp/print-css.js' },` :
+
+```ts
+// RWEB audits — Tier 1
+{ path: `${__dirname}/audits/bp/rweb-0106-no-autoplay.js` },
+{ path: `${__dirname}/audits/bp/rweb-0059-no-social-sdk.js` },
+{ path: `${__dirname}/audits/bp/rweb-0111-limit-analytics.js` },
+{ path: `${__dirname}/audits/bp/rweb-0082-limit-domains.js` },
+{ path: `${__dirname}/audits/bp/rweb-0112-no-redirects.js` },
+{ path: `${__dirname}/audits/bp/rweb-0060-service-worker.js` },
+// RWEB audits — Tier 2
+{ path: `${__dirname}/audits/bp/rweb-0042-no-inline-assets.js` },
+{ path: `${__dirname}/audits/bp/rweb-0055-no-canvas.js` },
+{ path: `${__dirname}/audits/bp/rweb-0032-limit-fonts.js` },
+{ path: `${__dirname}/audits/bp/rweb-0011-title-meta.js` },
+// RWEB audits — Tier 3
+{ path: `${__dirname}/audits/bp/rweb-0099-no-gif.js` },
+{ path: `${__dirname}/audits/bp/rweb-0009-no-animations.js` },
+{ path: `${__dirname}/audits/bp/rweb-0010-no-carousel.js` },
+{ path: `${__dirname}/audits/bp/rweb-0033-no-embedded-docs.js` },
+{ path: `${__dirname}/audits/bp/rweb-0039-css-containment.js` },
+{ path: `${__dirname}/audits/bp/rweb-0084-hsts.js` },
+{ path: `${__dirname}/audits/bp/rweb-0081-no-cookie-on-static.js` },
+```
+
+- [ ] **Étape 2 : Ajouter les 18 auditRefs dans `category.auditRefs`**
+
+Après `{ id: 'bp-print-css', weight: 0, group: 'ecoindex-best-practices' },` :
+
+```ts
+// RWEB audits — Tier 1
+{ id: 'rweb-0106-no-autoplay', weight: 0, group: 'ecoindex-best-practices' },
+{ id: 'rweb-0059-no-social-sdk', weight: 0, group: 'ecoindex-best-practices' },
+{ id: 'rweb-0111-limit-analytics', weight: 0, group: 'ecoindex-best-practices' },
+{ id: 'rweb-0082-limit-domains', weight: 0, group: 'ecoindex-best-practices' },
+{ id: 'rweb-0112-no-redirects', weight: 0, group: 'ecoindex-best-practices' },
+{ id: 'rweb-0060-service-worker', weight: 0, group: 'ecoindex-best-practices' },
+// RWEB audits — Tier 2
+{ id: 'rweb-0042-no-inline-assets', weight: 0, group: 'ecoindex-best-practices' },
+{ id: 'rweb-0055-no-canvas', weight: 0, group: 'ecoindex-best-practices' },
+{ id: 'rweb-0032-limit-fonts', weight: 0, group: 'ecoindex-best-practices' },
+{ id: 'rweb-0011-title-meta', weight: 0, group: 'ecoindex-best-practices' },
+// RWEB audits — Tier 3
+{ id: 'rweb-0099-no-gif', weight: 0, group: 'ecoindex-best-practices' },
+{ id: 'rweb-0009-no-animations', weight: 0, group: 'ecoindex-best-practices' },
+{ id: 'rweb-0010-no-carousel', weight: 0, group: 'ecoindex-best-practices' },
+{ id: 'rweb-0033-no-embedded-docs', weight: 0, group: 'ecoindex-best-practices' },
+{ id: 'rweb-0039-css-containment', weight: 0, group: 'ecoindex-best-practices' },
+{ id: 'rweb-0084-hsts', weight: 0, group: 'ecoindex-best-practices' },
+{ id: 'rweb-0081-no-cookie-on-static', weight: 0, group: 'ecoindex-best-practices' },
+```
+
+- [ ] **Étape 3 : Build complet**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core build
+```
+
+Attendu : build réussi, dossier `dist/` à jour avec les 18 nouveaux fichiers `.js`.
+
+- [ ] **Étape 4 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/plugin.ts
+git commit -m "feat(plugin): register 18 RWEB audits in plugin.ts"
+```
+
+---
+
+## Task 12 — Infrastructure de test
+
+**Fichiers :**
+- Créer : `test/test-pages/bp-violations.html`
+- Modifier : `test/test-pages/expected-results.json`
+- Modifier : `test/test-pages/verify-results.js`
+- Modifier : `test/test-ecoindex-lh-plugin-ts/.lighthouserc.cjs`
+
+- [ ] **Étape 1 : Créer `test/test-pages/bp-violations.html`**
+
+```html
+<!DOCTYPE html>
+<!-- No <title> intentionally: tests RWEB_0011 -->
+<html lang="en">
+<head>
+  <!-- No meta description intentionally: tests RWEB_0011 -->
+  <meta charset="UTF-8" />
+  <style>
+    /* inline style block 1: tests RWEB_0042 */
+    body { margin: 0; }
+  </style>
+  <style>
+    /* inline style block 2: tests RWEB_0042 */
+    @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+    .spinner { animation: spin 1s infinite; }
+  </style>
+</head>
+<body>
+
+  <!-- Tests RWEB_0106: autoplay video -->
+  <video autoplay muted loop src="placeholder.mp4" width="1" height="1"></video>
+
+  <!-- Tests RWEB_0055: canvas -->
+  <canvas id="c" width="10" height="10"></canvas>
+
+  <!-- Tests RWEB_0099: animated GIF -->
+  <img src="placeholder.gif" alt="gif" width="1" height="1" />
+
+  <!-- Tests RWEB_0033: embedded document -->
+  <embed src="doc.pdf" width="1" height="1" />
+
+  <!-- Tests RWEB_0009: animated element -->
+  <div class="spinner" aria-hidden="true"></div>
+
+  <!-- inline script block 1: tests RWEB_0042 -->
+  <script>var a = 1;</script>
+  <!-- inline script block 2: tests RWEB_0042 -->
+  <script>var b = 2;</script>
+  <!-- inline script block 3: tests RWEB_0042 -->
+  <script>var c = 3;</script>
+
+</body>
+</html>
+```
+
+> Cette page déclenche intentionnellement les violations suivantes :
+> - RWEB_0011 (pas de `<title>`, pas de `<meta description>`) → score 0
+> - RWEB_0042 (2 `<style>` + 3 `<script>` = 5 blocs inline > 2) → score 0
+> - RWEB_0055 (`<canvas>`) → score 0
+> - RWEB_0099 (`<img src="placeholder.gif">`) → score 0
+> - RWEB_0033 (`<embed src="doc.pdf">`) → score 0
+> - RWEB_0106 (`<video autoplay>`) → score 0
+> - RWEB_0009 (`.spinner` avec `animation: spin`) → score 0
+
+- [ ] **Étape 2 : Ajouter `bp-violations` dans `expected-results.json`**
+
+Ajouter avant le `}` de fermeture final :
+
+```json
+,
+"bp-violations": {
+  "description": "Page with intentional BP violations for RWEB audits testing",
+  "expectedScore": {
+    "min": 95,
+    "max": 100
+  },
+  "expectedNodes": {
+    "value": 15,
+    "tolerance": 5
+  },
+  "expectedRequests": {
+    "value": 1,
+    "tolerance": 1
+  },
+  "expectedBPAudits": {
+    "rweb-0011-title-meta": 0,
+    "rweb-0042-no-inline-assets": 0,
+    "rweb-0055-no-canvas": 0,
+    "rweb-0099-no-gif": 0,
+    "rweb-0033-no-embedded-docs": 0,
+    "rweb-0106-no-autoplay": 0,
+    "rweb-0009-no-animations": 0,
+    "rweb-0060-service-worker": 0,
+    "rweb-0084-hsts": 0
+  },
+  "note": "RWEB_0059, RWEB_0081, RWEB_0112 pass (no external requests on localhost)"
+}
+```
+
+- [ ] **Étape 3 : Étendre `verify-results.js` pour supporter `expectedBPAudits`**
+
+Dans la fonction `verifyResultsWithLHR`, après le bloc `// Additional checks` (ligne ~112), ajouter :
+
+```js
+  // Verify BP audit scores
+  if (expected.expectedBPAudits) {
+    for (const [auditId, expectedScore] of Object.entries(expected.expectedBPAudits)) {
+      const audit = lhr.audits[auditId]
+      if (!audit) {
+        console.error(`❌ BP audit not found: ${auditId}`)
+        allPassed = false
+        continue
+      }
+      if (audit.score === expectedScore) {
+        console.log(`✅ ${auditId}: score ${audit.score}`)
+      } else {
+        console.error(`❌ ${auditId}: score ${audit.score} (expected ${expectedScore})`)
+        allPassed = false
+      }
+    }
+  }
+```
+
+Dans `URL_TO_PAGE_KEY`, ajouter :
+
+```js
+'http://localhost:3000/bp-violations': 'bp-violations',
+```
+
+- [ ] **Étape 4 : Ajouter l'URL dans `.lighthouserc.cjs`**
+
+Dans le tableau `url` de `collect`, ajouter :
+
+```js
+'http://localhost:3000/bp-violations',
+```
+
+- [ ] **Étape 5 : Commit**
+
+```bash
+git add test/test-pages/bp-violations.html \
+        test/test-pages/expected-results.json \
+        test/test-pages/verify-results.js \
+        test/test-ecoindex-lh-plugin-ts/.lighthouserc.cjs
+git commit -m "test: add bp-violations test page and extend verify-results.js for BP audits"
+```
+
+---
+
+## Task 13 — Build complet et tests LHCI
+
+- [ ] **Étape 1 : Format check**
+
+```bash
+pnpm format:check
+```
+
+Si des erreurs : `pnpm format:write`, puis vérifier à nouveau.
+
+- [ ] **Étape 2 : Typecheck global**
+
+```bash
+pnpm typecheck
+```
+
+Attendu : pas d'erreur TypeScript.
+
+- [ ] **Étape 3 : Lint**
+
+```bash
+pnpm lint
+```
+
+Attendu : pas de warning ni d'erreur ESLint.
+
+- [ ] **Étape 4 : Build**
+
+```bash
+pnpm build
+```
+
+Attendu : build réussi.
+
+- [ ] **Étape 5 : Démarrer le serveur de test**
+
+```bash
+pnpm test:server:start
+```
+
+Attendu : `Test server ready` dans la sortie.
+
+- [ ] **Étape 6 : Lancer LHCI sur le test plugin-ts**
+
+```bash
+pnpm --filter @ecoindex-lh-test/plugin-core test
+```
+
+Ou directement depuis le dossier test :
+
+```bash
+cd test/test-ecoindex-lh-plugin-ts && npx lhci autorun
+```
+
+Attendu : toutes les pages existantes passent. La page `bp-violations` doit avoir les scores BP audits = 0 pour les violations déclarées dans `expectedBPAudits`.
+
+- [ ] **Étape 7 : Vérifier les résultats**
+
+```bash
+node test/test-pages/verify-results.js
+```
+
+Attendu : `✅` pour chaque page, y compris `bp-violations`.
+
+- [ ] **Étape 8 : Arrêter le serveur**
+
+```bash
+pnpm test:server:stop
+```
+
+---
+
+## Task 14 — Script generate-refs-urls.ts
+
+**Fichiers :**
+- Créer : `scripts/generate-refs-urls.ts`
+- Modifier : `package.json` (racine)
+
+- [ ] **Étape 1 : Ajouter tsx comme devDependency racine**
+
+```bash
+pnpm add -D tsx -w
+```
+
+Attendu : `tsx` ajouté dans le `package.json` racine sous `devDependencies`.
+
+- [ ] **Étape 2 : Créer `scripts/generate-refs-urls.ts`**
+
+```ts
+#!/usr/bin/env tsx
+/**
+ * Regenerates the rweb.* section of refs-urls.ts from the RWEB API.
+ * Usage: pnpm refs:update [-- --version 1.0.0]
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const RWEB_IDS = [
+  '0031', '0106', '0059', '0111', '0082', '0112', '0060',
+  '0042', '0055', '0032', '0011',
+  '0099', '0009', '0010', '0033', '0039', '0084', '0081',
+]
+
+const LOCALES = ['fr', 'en']
+
+const OUTPUT_FILE = path.join(
+  __dirname,
+  '../libs/ecoindex-lh-plugin-ts/src/audits/bp/refs-urls.ts',
+)
+
+function parseArgs(): { version: string } {
+  const args = process.argv.slice(2)
+  const versionIdx = args.indexOf('--version')
+  return {
+    version: versionIdx !== -1 && args[versionIdx + 1] ? args[versionIdx + 1] : 'latest',
+  }
+}
+
+async function fetchUrl(id: string, lang: string, version: string): Promise<string> {
+  const apiUrl = `https://rweb.greenit.fr/api/fiches/${id}?lang=${lang}&version=${version}`
+  try {
+    const res = await fetch(apiUrl)
+    if (!res.ok) {
+      console.warn(`  ⚠️  API ${res.status} for ${id} (${lang}) — using fallback URL`)
+      return `https://rweb.greenit.fr/${lang}/fiches/${id}`
+    }
+    const data = (await res.json()) as { url?: string }
+    return data.url ?? `https://rweb.greenit.fr/${lang}/fiches/${id}`
+  } catch (err) {
+    console.warn(`  ⚠️  Fetch failed for ${id} (${lang}): ${err} — using fallback URL`)
+    return `https://rweb.greenit.fr/${lang}/fiches/${id}`
+  }
+}
+
+async function main() {
+  const { version } = parseArgs()
+  console.log(`Fetching RWEB refs — version: ${version}`)
+
+  const rweb: Record<string, Record<string, string>> = {}
+
+  for (const id of RWEB_IDS) {
+    const key = `rweb_${id}`
+    rweb[key] = {}
+    for (const lang of LOCALES) {
+      process.stdout.write(`  ${key} (${lang})... `)
+      const url = await fetchUrl(id, lang, version)
+      rweb[key][lang] = url
+      console.log(url)
+    }
+  }
+
+  // Read current file to preserve non-rweb sections
+  const current = fs.readFileSync(OUTPUT_FILE, 'utf8')
+  const beforeRwebGenerated = current.replace(
+    /\/\/ Entrées générées[\s\S]*$/,
+    '',
+  )
+
+  const rwwebLines = Object.entries(rweb)
+    .map(([key, urls]) => {
+      const localeLines = Object.entries(urls)
+        .map(([lang, url]) => `      ${lang}: '${url}',`)
+        .join('\n')
+      return `    ${key}: {\n${localeLines}\n    },`
+    })
+    .join('\n')
+
+  const generatedBlock = `    // Entrées générées — mettre à jour avec : pnpm refs:update\n${rwwebLines}\n  },\n}`
+
+  const newContent =
+    `// Generated by scripts/generate-refs-urls.ts — RWEB version: ${version}\n` +
+    beforeRwebGenerated.replace(/^\/\/.*\n/, '') +
+    generatedBlock
+
+  fs.writeFileSync(OUTPUT_FILE, newContent, 'utf8')
+  console.log(`\n✅ Written to ${path.relative(process.cwd(), OUTPUT_FILE)}`)
+}
+
+main().catch(err => {
+  console.error(err)
+  process.exit(1)
+})
+```
+
+- [ ] **Étape 3 : Ajouter les scripts dans `package.json` racine**
+
+Dans l'objet `"scripts"`, ajouter après `"lhci:install:git-lfs"` :
+
+```json
+"refs:update": "tsx scripts/generate-refs-urls.ts",
+"refs:update:version": "tsx scripts/generate-refs-urls.ts -- --version"
+```
+
+- [ ] **Étape 4 : Tester le script en local (optionnel — nécessite réseau)**
+
+```bash
+pnpm refs:update
+```
+
+Attendu : `refs-urls.ts` mis à jour avec les URLs de l'API RWEB.
+
+- [ ] **Étape 5 : Commit**
+
+```bash
+git add scripts/generate-refs-urls.ts package.json
+git commit -m "feat(scripts): add generate-refs-urls.ts to update RWEB URLs from API"
+```
+
+---
+
+## Task 15 — Checks finaux et changeset
+
+- [ ] **Étape 1 : Format check**
+
+```bash
+pnpm format:check
+```
+
+- [ ] **Étape 2 : Typecheck**
+
+```bash
+pnpm typecheck
+```
+
+- [ ] **Étape 3 : Lint**
+
+```bash
+pnpm lint
+```
+
+- [ ] **Étape 4 : Créer le changeset**
+
+```bash
+pnpm changeset
+```
+
+Sélectionner `lighthouse-plugin-ecoindex-core`, type `minor` (nouvelles fonctionnalités), message :
+
+```
+feat: add 18 RWEB audits (Tier 1/2/3) with BPGatherer and generate-refs-urls.ts script
+```
+
+- [ ] **Étape 5 : Commit du changeset**
+
+```bash
+git add .changeset/
+git commit -m "chore: add changeset for 18 new RWEB audits"
+```

--- a/.superpowers/plans/2026-05-10-i18n-phase0-lang-propagation.md
+++ b/.superpowers/plans/2026-05-10-i18n-phase0-lang-propagation.md
@@ -1,0 +1,313 @@
+# i18n Phase 0 — Propagation `lang` (CLI → Lighthouse locale)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter l'option `--lang` au CLI et la propager jusqu'à `settings.locale` dans Lighthouse, de sorte que les audits du plugin reçoivent la locale via `context.settings.locale`.
+
+**Architecture:** Le flag `--lang` est ajouté à yargs dans `cli-flags.ts`, typé dans `CliFlags` (courses), puis passé à `getLighthouseConfig()` qui l'injecte dans `settings.locale`. Aucun string traduit dans Phase 0 — uniquement la tuyauterie.
+
+**Tech Stack:** TypeScript, yargs, Lighthouse 13 (`LH.UserFlow.Options`), pnpm workspaces.
+
+---
+
+## Carte des fichiers
+
+| Fichier | Changement |
+|---------|------------|
+| `libs/ecoindex-lh-courses/src/types/index.d.ts` | Ajouter `lang?: 'en' \| 'fr'` dans `CliFlags` |
+| `apps/ecoindex-lh-cli/src/cli-flags.ts` | Ajouter `.option('lang', ...)` dans `collectCommand()` |
+| `libs/ecoindex-lh-courses/src/commands.ts` | Ajouter param `lang` à `getLighthouseConfig()`, injecter `locale` |
+| `libs/ecoindex-lh-courses/src/run.ts` | Passer `cliFlags['lang']` aux 2 appels de `getLighthouseConfig()` |
+
+---
+
+## Task 1 — Typage `lang` dans CliFlags
+
+**Fichiers :**
+- Modifier : `libs/ecoindex-lh-courses/src/types/index.d.ts`
+
+- [ ] **Étape 1 : Ajouter `lang` dans l'interface `CliFlags`**
+
+Dans `libs/ecoindex-lh-courses/src/types/index.d.ts`, l'interface `CliFlags` commence ainsi :
+```ts
+export interface CliFlags {
+  auth?: never | Auth
+```
+
+Ajouter `lang` comme première propriété optionnelle :
+
+```ts
+export interface CliFlags {
+  lang?: 'en' | 'fr'
+  auth?: never | Auth
+```
+
+- [ ] **Étape 2 : Vérifier le typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-courses typecheck
+```
+
+Attendu : aucune erreur.
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+git add libs/ecoindex-lh-courses/src/types/index.d.ts
+git commit -m "feat(i18n): add lang to CliFlags type"
+```
+
+---
+
+## Task 2 — Option `--lang` dans yargs
+
+**Fichiers :**
+- Modifier : `apps/ecoindex-lh-cli/src/cli-flags.ts`
+
+- [ ] **Étape 1 : Ajouter `.option('lang', ...)` dans `collectCommand()`**
+
+Dans `apps/ecoindex-lh-cli/src/cli-flags.ts`, la fonction `collectCommand()` liste des `.option(...)` en chaîne. Après le dernier `.option('auth', ...)` (et avant `.epilogue(...)`), ajouter :
+
+```ts
+    .option('lang', {
+      type: 'string',
+      choices: ['en', 'fr'] as const,
+      default: 'en' as const,
+      description: 'Language for the report output. Default is "en".',
+    })
+```
+
+- [ ] **Étape 2 : Vérifier le typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-cli typecheck
+```
+
+Attendu : aucune erreur.
+
+- [ ] **Étape 3 : Vérifier manuellement que `--lang` apparaît dans l'aide**
+
+```bash
+node apps/ecoindex-lh-cli/src/bin.ts collect --help 2>/dev/null | grep lang || \
+pnpm --filter lighthouse-plugin-ecoindex-cli build && \
+node apps/ecoindex-lh-cli/dist/bin.js collect --help | grep lang
+```
+
+Attendu : une ligne mentionnant `--lang` avec `choices: "en", "fr"`.
+
+- [ ] **Étape 4 : Commit**
+
+```bash
+git add apps/ecoindex-lh-cli/src/cli-flags.ts
+git commit -m "feat(i18n): add --lang option to CLI collect command"
+```
+
+---
+
+## Task 3 — `getLighthouseConfig()` injecte `locale`
+
+**Fichiers :**
+- Modifier : `libs/ecoindex-lh-courses/src/commands.ts` (ligne 143)
+
+- [ ] **Étape 1 : Ajouter le paramètre `lang` et injecter `locale` dans les settings**
+
+La signature actuelle (ligne 143) est :
+```ts
+function getLighthouseConfig(
+  isWarm = false,
+  stepName = `undefined`,
+  onlyCategories = ['lighthouse-plugin-ecoindex-core'],
+  userAgent: string,
+): LH.UserFlow.Options {
+  return {
+    name: stepName,
+    config: {
+      ...custom_config_default,
+      settings: {
+        ...custom_config_default.settings,
+        formFactor: custom_config_default.settings.formFactor as
+          | 'mobile'
+          | 'desktop',
+        onlyCategories: onlyCategories,
+        emulatedUserAgent:
+          userAgent === 'random'
+            ? userAgentStrings[
+                Math.floor(Math.random() * userAgentStrings.length)
+              ]
+            : userAgent,
+        disableStorageReset: isWarm,
+      },
+    },
+  }
+}
+```
+
+Remplacer par :
+```ts
+function getLighthouseConfig(
+  isWarm = false,
+  stepName = `undefined`,
+  onlyCategories = ['lighthouse-plugin-ecoindex-core'],
+  userAgent: string,
+  lang: 'en' | 'fr' = 'en',
+): LH.UserFlow.Options {
+  return {
+    name: stepName,
+    config: {
+      ...custom_config_default,
+      settings: {
+        ...custom_config_default.settings,
+        formFactor: custom_config_default.settings.formFactor as
+          | 'mobile'
+          | 'desktop',
+        onlyCategories: onlyCategories,
+        emulatedUserAgent:
+          userAgent === 'random'
+            ? userAgentStrings[
+                Math.floor(Math.random() * userAgentStrings.length)
+              ]
+            : userAgent,
+        disableStorageReset: isWarm,
+        locale: lang,
+      },
+    },
+  }
+}
+```
+
+- [ ] **Étape 2 : Vérifier le typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-courses typecheck
+```
+
+Attendu : aucune erreur. Si TypeScript se plaint de `locale` (type `string` attendu par LH), caster : `locale: lang as string`.
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+git add libs/ecoindex-lh-courses/src/commands.ts
+git commit -m "feat(i18n): pass locale to Lighthouse settings in getLighthouseConfig"
+```
+
+---
+
+## Task 4 — Passer `cliFlags['lang']` aux call sites
+
+**Fichiers :**
+- Modifier : `libs/ecoindex-lh-courses/src/run.ts`
+
+- [ ] **Étape 1 : Identifier les 2 appels de `getLighthouseConfig()` dans run.ts**
+
+Il y en a exactement deux, aux environs des lignes 90 et 112 :
+
+```ts
+// Appel 1 (ligne ~90)
+getLighthouseConfig(
+  true,
+  `Warm Navigation: ${uniqUrls[0]}`,
+  cliFlags['audit-category'],
+  cliFlags['user-agent'],
+)
+
+// Appel 2 (ligne ~112)
+getLighthouseConfig(
+  false,
+  `Cold Navigation: ${uniqUrls[index]}`,
+  cliFlags['audit-category'],
+  cliFlags['user-agent'],
+)
+```
+
+Ajouter `cliFlags['lang']` comme 5e argument dans les deux appels :
+
+```ts
+// Appel 1
+getLighthouseConfig(
+  true,
+  `Warm Navigation: ${uniqUrls[0]}`,
+  cliFlags['audit-category'],
+  cliFlags['user-agent'],
+  cliFlags['lang'],
+)
+
+// Appel 2
+getLighthouseConfig(
+  false,
+  `Cold Navigation: ${uniqUrls[index]}`,
+  cliFlags['audit-category'],
+  cliFlags['user-agent'],
+  cliFlags['lang'],
+)
+```
+
+- [ ] **Étape 2 : Vérifier le typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-courses typecheck
+pnpm typecheck:strict
+```
+
+Attendu : aucune erreur.
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+git add libs/ecoindex-lh-courses/src/run.ts
+git commit -m "feat(i18n): thread cliFlags lang to getLighthouseConfig call sites"
+```
+
+---
+
+## Task 5 — Vérification end-to-end
+
+- [ ] **Étape 1 : Build complet**
+
+```bash
+pnpm build
+```
+
+Attendu : aucune erreur de compilation.
+
+- [ ] **Étape 2 : Vérifier les pre-commit checks**
+
+```bash
+pnpm format:check && pnpm typecheck && pnpm lint && pnpm typecheck:strict
+```
+
+Attendu : tout passe.
+
+- [ ] **Étape 3 : Vérifier que `--lang fr` est bien passé à Lighthouse**
+
+Insérer temporairement un `console.log` dans `getLighthouseConfig` juste avant le `return` pour confirmer :
+```ts
+console.log('[i18n] locale =', lang)
+```
+
+Lancer :
+```bash
+node dist/apps/ecoindex-lh-cli/bin.js collect --url https://ecoindex.fr/ --lang fr
+```
+
+Attendu dans la console : `[i18n] locale = fr`.  
+Supprimer le `console.log` ensuite.
+
+- [ ] **Étape 4 : Changeset**
+
+Créer `.changeset/<nom-aleatoire>.md` :
+
+```markdown
+---
+"lighthouse-plugin-ecoindex-cli": minor
+"lighthouse-plugin-ecoindex-courses": minor
+---
+
+feat(i18n): add --lang option and propagate locale to Lighthouse settings
+```
+
+- [ ] **Étape 5 : Commit final**
+
+```bash
+git add .changeset/
+git commit -m "chore(changeset): add changeset for i18n phase 0"
+```

--- a/.superpowers/plans/2026-05-10-i18n-phase1-plugin-strings.md
+++ b/.superpowers/plans/2026-05-10-i18n-phase1-plugin-strings.md
@@ -1,0 +1,732 @@
+# i18n Phase 1 — Infrastructure Plugin (Strings + Locales)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Instrumenter les ~47 fichiers d'audit du plugin avec `UIStrings` + `createIcuMessageFn`, générer `locales/en.json` et créer `locales/fr.json`, enregistrer la locale FR dans `plugin.ts`, et ajouter `UIStrings` aux groupes et à la catégorie du plugin.
+
+**Architecture:** Un script one-shot `scripts/i18n-extract-patch.ts` extrait les strings statiques (`title`, `failureTitle`, `description`) des fichiers d'audit, les remplace par des appels `str_(UIStrings.xxx)`, et écrit `en.json`. Six fichiers complexes (DYNAMIC template literals ou logique spéciale) sont exclus du script et patchés manuellement. `fr.json` est créé en Task 6 à partir de `en.json` comme référence, avec les traductions complètes EN→FR fournies dans ce plan.
+
+**Tech Stack:** TypeScript, tsx, Lighthouse 13 (`createIcuMessageFn`, `registerLocaleData`), pnpm.
+
+---
+
+## Carte des fichiers
+
+| Fichier | Changement |
+|---------|------------|
+| `libs/ecoindex-lh-plugin-ts/src/locales/en.json` | Généré par le script (Task 4) |
+| `libs/ecoindex-lh-plugin-ts/src/locales/fr.json` | Créé manuellement (Task 6) |
+| `libs/ecoindex-lh-plugin-ts/src/plugin.ts` | UIStrings groupes/catégorie + registerLocaleData (Tasks 1–2) |
+| `libs/ecoindex-lh-plugin-ts/src/audits/*.ts` (~7 fichiers) | Patchés par le script sauf warn-nodes-count |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/*.ts` (~39 fichiers) | Patchés par le script sauf 5 fichiers DYNAMIC |
+| `libs/ecoindex-lh-plugin-ts/src/audits/warn-nodes-count.ts` | Patché manuellement (Task 5) |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/thegreenwebfoundation.ts` | Patché manuellement (Task 5) |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-cookie-size.ts` | Patché manuellement (Task 5) |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-redirects.ts` | Patché manuellement (Task 5) |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-domains.ts` | Patché manuellement (Task 5) |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-fonts.ts` | Patché manuellement (Task 5) |
+| `scripts/i18n-extract-patch.ts` | Nouveau script one-shot |
+| `package.json` (racine) | Ajout `"i18n:extract"` dans scripts |
+
+**Skip list du script (DYNAMIC ou logique complexe) :**
+- `warn-nodes-count.ts` — description utilise une variable
+- `thegreenwebfoundation.ts` — logique réseau complexe
+- `rweb-cookie-size.ts` — `MAX_COOKIE_BYTES = 512` dans un template literal
+- `rweb-no-redirects.ts` — `MAX_REDIRECTS = 1` dans un template literal
+- `rweb-limit-domains.ts` — `MAX_DOMAINS = 5` dans un template literal
+- `rweb-limit-fonts.ts` — `MAX_FONT_FAMILIES = 2` dans un template literal
+
+---
+
+## Task 1 — Créer le répertoire locales et ajouter `registerLocaleData` dans `plugin.ts`
+
+**Fichiers :**
+- Créer : `libs/ecoindex-lh-plugin-ts/src/locales/` (répertoire)
+- Modifier : `libs/ecoindex-lh-plugin-ts/src/plugin.ts`
+
+- [ ] **Étape 1 : Créer le répertoire locales**
+
+```bash
+mkdir -p libs/ecoindex-lh-plugin-ts/src/locales
+```
+
+- [ ] **Étape 2 : Modifier les imports dans `plugin.ts`**
+
+Le fichier commence actuellement par :
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+
+import { getVersion } from './utils/index.js'
+```
+
+Remplacer par :
+
+```ts
+import * as LH from 'lighthouse/types/lh.js'
+import { registerLocaleData } from 'lighthouse/shared/localization/format.js'
+
+import { getVersion } from './utils/index.js'
+import frLocale from './locales/fr.json' assert { type: 'json' }
+
+registerLocaleData('fr', frLocale)
+```
+
+- [ ] **Étape 3 : Vérifier le typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core typecheck
+```
+
+Attendu : erreur sur `./locales/fr.json` (absent). C'est normal. Si TypeScript se plaint de la syntaxe `assert { type: 'json' }`, vérifier que `tsconfig.json` du package a `"resolveJsonModule": true`.
+
+- [ ] **Étape 4 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/plugin.ts
+git commit -m "feat(i18n): add registerLocaleData and fr.json import to plugin.ts"
+```
+
+---
+
+## Task 2 — UIStrings pour les groupes et la catégorie dans `plugin.ts`
+
+**Fichiers :**
+- Modifier : `libs/ecoindex-lh-plugin-ts/src/plugin.ts`
+
+- [ ] **Étape 1 : Ajouter l'import `createIcuMessageFn` et le bloc `UIStrings` dans `plugin.ts`**
+
+Après la ligne `registerLocaleData('fr', frLocale)`, insérer :
+
+```ts
+import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'
+
+const UIStrings = {
+  groupEcologicTitle: 'Ecoindex results',
+  groupEcologicDescription: 'Ecoindex revealant metrics.',
+  groupTechnicTitle: 'Technical results',
+  groupTechnicDescription: 'Technical metrics.',
+  groupBpTitle: '#RWEB web eco-design: 115 best practices',
+  groupBpDescription:
+    'CNUMR (Collectif Conception Numérique Responsable) "115 best practices" reference framework.',
+  groupRgesnTitle:
+    '#RGESN General eco-design guidelines for digital servicesBest practices',
+  groupRgesnDescription: 'General eco-design guidelines for digital services.',
+  groupOtherTitle: 'Other ecodesign best practices',
+  groupOtherDescription: 'Various best practices in eco-design.',
+  categoryTitle: 'Ecoindex',
+}
+const str_ = createIcuMessageFn(import.meta.url, UIStrings)
+```
+
+- [ ] **Étape 2 : Remplacer les strings hardcodées dans la section `groups`**
+
+Dans `plugin.ts`, remplacer la section `groups` (lignes ~141–163) par :
+
+```ts
+  groups: {
+    'ecoindex-ecologic': {
+      title: str_(UIStrings.groupEcologicTitle),
+      description: str_(UIStrings.groupEcologicDescription),
+    },
+    'ecoindex-technic': {
+      title: str_(UIStrings.groupTechnicTitle),
+      description: str_(UIStrings.groupTechnicDescription),
+    },
+    'ecoindex-best-practices': {
+      title: str_(UIStrings.groupBpTitle),
+      description: str_(UIStrings.groupBpDescription),
+    },
+    'ecoindex-rgesn-practices': {
+      title: str_(UIStrings.groupRgesnTitle),
+      description: str_(UIStrings.groupRgesnDescription),
+    },
+    'ecoindex-other-practices': {
+      title: str_(UIStrings.groupOtherTitle),
+      description: str_(UIStrings.groupOtherDescription),
+    },
+  },
+```
+
+- [ ] **Étape 3 : Remplacer le `title` hardcodé dans la section `category`**
+
+Dans la section `category`, remplacer uniquement le titre (la description contient `getVersion()` — la laisser en l'état) :
+
+```ts
+  category: {
+    title: str_(UIStrings.categoryTitle),
+    description:
+      '[Ecoindex®](https://www.ecoindex.fr/) revealant metrics, by [GreenIT.fr®](https://www.greenit.fr).  ' +
+      '[GitHub](https://github.com/NovaGaia/.). Version: ' +
+      getVersion(),
+```
+
+- [ ] **Étape 4 : Typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core typecheck
+```
+
+Attendu : toujours l'erreur sur `fr.json` absent. Corriger toute autre erreur de type.
+
+- [ ] **Étape 5 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/plugin.ts
+git commit -m "feat(i18n): add UIStrings to plugin.ts groups and category"
+```
+
+---
+
+## Task 3 — Écrire le script `i18n-extract-patch.ts`
+
+**Fichiers :**
+- Créer : `scripts/i18n-extract-patch.ts`
+- Modifier : `package.json` (racine)
+
+- [ ] **Étape 1 : Créer `scripts/i18n-extract-patch.ts` avec le contenu suivant**
+
+```ts
+#!/usr/bin/env tsx
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const PLUGIN_SRC = path.join(__dirname, '../libs/ecoindex-lh-plugin-ts/src')
+const LOCALES_DIR = path.join(PLUGIN_SRC, 'locales')
+
+// Skip: files with dynamic template literals or complex internal logic
+const SKIP = new Set([
+  'warn-nodes-count.ts',
+  'thegreenwebfoundation.ts',
+  'rweb-cookie-size.ts',
+  'rweb-no-redirects.ts',
+  'rweb-limit-domains.ts',
+  'rweb-limit-fonts.ts',
+])
+
+function collectAuditFiles(): Array<{ abs: string; rel: string }> {
+  const result: Array<{ abs: string; rel: string }> = []
+  for (const subdir of ['audits', 'audits/bp']) {
+    const dir = path.join(PLUGIN_SRC, subdir)
+    for (const name of fs.readdirSync(dir).sort()) {
+      if (name.endsWith('.ts') && !SKIP.has(name)) {
+        result.push({
+          abs: path.join(dir, name),
+          rel: `${subdir}/${name.replace('.ts', '.js')}`,
+        })
+      }
+    }
+  }
+  return result
+}
+
+function extractStaticStrings(content: string): Record<string, string> {
+  const strings: Record<string, string> = {}
+  for (const line of content.split('\n')) {
+    const m = line.match(
+      /^\s+(title|failureTitle|description):\s+'((?:[^'\\]|\\.)*)',?\s*$/,
+    )
+    if (m) strings[m[1]] = m[2].replace(/\\'/g, "'")
+  }
+  return strings
+}
+
+function patchContent(content: string, strings: Record<string, string>): string {
+  // Add createIcuMessageFn import after the last import block
+  const importLine = `import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'`
+  if (!content.includes('createIcuMessageFn')) {
+    // Find position after the contiguous import block at the top
+    content = content.replace(
+      /^((?:import[^\n]+\n)+)/m,
+      `$1${importLine}\n`,
+    )
+  }
+
+  // Build UIStrings block
+  const entries = Object.entries(strings)
+    .map(([k, v]) => `  ${k}: '${v.replace(/'/g, "\\'")}',`)
+    .join('\n')
+  const uiBlock =
+    `\nconst UIStrings = {\n${entries}\n}\n` +
+    `const str_ = createIcuMessageFn(import.meta.url, UIStrings)\n`
+
+  // Insert UIStrings block just before the first export declaration
+  content = content.replace(/\n(export (default )?class )/, `${uiBlock}\n$1`)
+
+  // Replace each matched string literal with str_(UIStrings.key)
+  for (const key of Object.keys(strings)) {
+    content = content.replace(
+      new RegExp(`(\\b${key}:\\s*)'(?:[^'\\\\]|\\\\.)*'`),
+      `$1str_(UIStrings.${key})`,
+    )
+  }
+
+  return content
+}
+
+function main() {
+  fs.mkdirSync(LOCALES_DIR, { recursive: true })
+
+  const enJson: Record<string, string> = {}
+  const files = collectAuditFiles()
+
+  for (const { abs, rel } of files) {
+    const original = fs.readFileSync(abs, 'utf-8')
+    const strings = extractStaticStrings(original)
+
+    if (Object.keys(strings).length === 0) {
+      console.log(`[skip] ${rel} — no static strings found`)
+      continue
+    }
+
+    for (const [k, v] of Object.entries(strings)) {
+      enJson[`${rel} | ${k}`] = v
+    }
+
+    const patched = patchContent(original, strings)
+    fs.writeFileSync(abs, patched, 'utf-8')
+    console.log(`[patch] ${rel} — ${Object.keys(strings).join(', ')}`)
+  }
+
+  fs.writeFileSync(
+    path.join(LOCALES_DIR, 'en.json'),
+    JSON.stringify(enJson, null, 2) + '\n',
+    'utf-8',
+  )
+
+  console.log(`\n✅ en.json written with ${Object.keys(enJson).length} keys`)
+  console.log('⚠️  Patch manually the 6 files in the skip list (Task 5)')
+  console.log('⚠️  Create fr.json from en.json structure (Task 6)')
+}
+
+main()
+```
+
+- [ ] **Étape 2 : Ajouter le script `i18n:extract` dans le `package.json` racine**
+
+Dans `package.json` racine, dans la section `"scripts"`, après la ligne `"refs:update:version": "tsx scripts/generate-refs-urls.ts -- --version"`, ajouter :
+
+```json
+    "i18n:extract": "tsx scripts/i18n-extract-patch.ts",
+```
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+git add scripts/i18n-extract-patch.ts package.json
+git commit -m "feat(i18n): add i18n-extract-patch script"
+```
+
+---
+
+## Task 4 — Exécuter le script et vérifier les patches
+
+- [ ] **Étape 1 : Lancer le script**
+
+```bash
+pnpm i18n:extract
+```
+
+Sortie attendue : lignes `[patch] audits/xxx.js — title, failureTitle, ...` pour ~40 fichiers, puis `✅ en.json written with NNN keys`.
+
+- [ ] **Étape 2 : Vérifier `en.json` généré**
+
+```bash
+cat libs/ecoindex-lh-plugin-ts/src/locales/en.json | head -20
+```
+
+Attendu : JSON valide, clés du format `"audits/ecoindex-score.js | title"`.
+
+- [ ] **Étape 3 : Vérifier un fichier patché**
+
+```bash
+head -25 libs/ecoindex-lh-plugin-ts/src/audits/ecoindex-score.ts
+```
+
+Attendu : import `createIcuMessageFn`, const `UIStrings`, const `str_` présents. Les `title:` et `failureTitle:` dans `static get meta()` pointent vers `str_(UIStrings.xxx)`.
+
+- [ ] **Étape 4 : Typecheck**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core typecheck
+```
+
+Attendu : uniquement l'erreur sur `fr.json` absent. Corriger toute autre erreur de typage introduite par le script avant de continuer.
+
+- [ ] **Étape 5 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/ libs/ecoindex-lh-plugin-ts/src/locales/en.json
+git commit -m "feat(i18n): apply i18n-extract-patch to audit files, generate en.json"
+```
+
+---
+
+## Task 5 — Patches manuels des 6 fichiers complexes
+
+**Fichiers :**
+- `libs/ecoindex-lh-plugin-ts/src/audits/warn-nodes-count.ts`
+- `libs/ecoindex-lh-plugin-ts/src/audits/bp/thegreenwebfoundation.ts`
+- `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-cookie-size.ts`
+- `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-redirects.ts`
+- `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-domains.ts`
+- `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-fonts.ts`
+
+Pour chaque fichier :
+1. Lire le fichier
+2. Ajouter l'import `createIcuMessageFn` après les imports existants
+3. Ajouter `const UIStrings = { ... }` et `const str_ = createIcuMessageFn(import.meta.url, UIStrings)` avant la classe
+4. Remplacer les strings dans `static get meta()` par des appels `str_(UIStrings.xxx)`
+5. Ajouter les clés correspondantes dans `en.json`
+
+### 5.1 — `warn-nodes-count.ts`
+
+- [ ] **Étape 1 : Patcher `warn-nodes-count.ts`**
+
+Ajouter après les imports :
+
+```ts
+import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'
+
+const UIStrings = {
+  title:
+    'Information ⚠️ : Ecoindex nodes number might be ≠ Lighthouse nodes number.',
+  failureTitle:
+    'Information ⚠️ : Ecoindex nodes number might be ≠ Lighthouse nodes number.',
+}
+const str_ = createIcuMessageFn(import.meta.url, UIStrings)
+```
+
+Dans `static get meta()`, remplacer `title:` et `failureTitle:` par `str_(UIStrings.title)` et `str_(UIStrings.failureTitle)`.
+
+Ajouter dans `en.json` (après les clés existantes) :
+
+```json
+"audits/warn-nodes-count.js | title": "Information ⚠️ : Ecoindex nodes number might be ≠ Lighthouse nodes number.",
+"audits/warn-nodes-count.js | failureTitle": "Information ⚠️ : Ecoindex nodes number might be ≠ Lighthouse nodes number."
+```
+
+### 5.2 — `thegreenwebfoundation.ts`
+
+- [ ] **Étape 2 : Patcher `thegreenwebfoundation.ts`**
+
+Ajouter après les imports :
+
+```ts
+import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'
+
+const UIStrings = {
+  title: 'The Green Web Foundation',
+  failureTitle: 'Your website is not hosted on a green web host.',
+}
+const str_ = createIcuMessageFn(import.meta.url, UIStrings)
+```
+
+Dans `static get meta()`, remplacer les strings. Ajouter dans `en.json` :
+
+```json
+"audits/bp/thegreenwebfoundation.js | title": "The Green Web Foundation",
+"audits/bp/thegreenwebfoundation.js | failureTitle": "Your website is not hosted on a green web host."
+```
+
+### 5.3 — `rweb-cookie-size.ts` (MAX_COOKIE_BYTES = 512)
+
+- [ ] **Étape 3 : Patcher `rweb-cookie-size.ts`**
+
+La constante `MAX_COOKIE_BYTES` vaut `512`. On bake la valeur dans la string UIStrings :
+
+```ts
+import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'
+
+const UIStrings = {
+  title: 'RWEB_0062 - Cookie size ≤ 512 bytes',
+  failureTitle: 'RWEB_0062 - Cookie header exceeds 512 bytes',
+}
+const str_ = createIcuMessageFn(import.meta.url, UIStrings)
+```
+
+Dans `static get meta()`, remplacer les template literals par `str_(UIStrings.title)` et `str_(UIStrings.failureTitle)`. Ajouter dans `en.json` :
+
+```json
+"audits/bp/rweb-cookie-size.js | title": "RWEB_0062 - Cookie size ≤ 512 bytes",
+"audits/bp/rweb-cookie-size.js | failureTitle": "RWEB_0062 - Cookie header exceeds 512 bytes"
+```
+
+### 5.4 — `rweb-no-redirects.ts` (MAX_REDIRECTS = 1)
+
+- [ ] **Étape 4 : Patcher `rweb-no-redirects.ts`**
+
+```ts
+import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'
+
+const UIStrings = {
+  title: 'RWEB_0112 - Avoid HTTP redirects (≤ 1)',
+  failureTitle: 'RWEB_0112 - Too many HTTP redirects (> 1)',
+}
+const str_ = createIcuMessageFn(import.meta.url, UIStrings)
+```
+
+Remplacer les template literals. Ajouter dans `en.json` :
+
+```json
+"audits/bp/rweb-no-redirects.js | title": "RWEB_0112 - Avoid HTTP redirects (≤ 1)",
+"audits/bp/rweb-no-redirects.js | failureTitle": "RWEB_0112 - Too many HTTP redirects (> 1)"
+```
+
+### 5.5 — `rweb-limit-domains.ts` (MAX_DOMAINS = 5)
+
+- [ ] **Étape 5 : Patcher `rweb-limit-domains.ts`**
+
+```ts
+import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'
+
+const UIStrings = {
+  title: 'RWEB_0082 - Limit resource domains (≤ 5)',
+  failureTitle: 'RWEB_0082 - Too many resource domains (> 5)',
+}
+const str_ = createIcuMessageFn(import.meta.url, UIStrings)
+```
+
+Remplacer les template literals. Ajouter dans `en.json` :
+
+```json
+"audits/bp/rweb-limit-domains.js | title": "RWEB_0082 - Limit resource domains (≤ 5)",
+"audits/bp/rweb-limit-domains.js | failureTitle": "RWEB_0082 - Too many resource domains (> 5)"
+```
+
+### 5.6 — `rweb-limit-fonts.ts` (MAX_FONT_FAMILIES = 2)
+
+- [ ] **Étape 6 : Patcher `rweb-limit-fonts.ts`**
+
+```ts
+import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'
+
+const UIStrings = {
+  title: 'RWEB_0032 - Limit font families (≤ 2)',
+  failureTitle: 'RWEB_0032 - Too many external font families (> 2)',
+}
+const str_ = createIcuMessageFn(import.meta.url, UIStrings)
+```
+
+Remplacer les template literals. Ajouter dans `en.json` :
+
+```json
+"audits/bp/rweb-limit-fonts.js | title": "RWEB_0032 - Limit font families (≤ 2)",
+"audits/bp/rweb-limit-fonts.js | failureTitle": "RWEB_0032 - Too many external font families (> 2)"
+```
+
+- [ ] **Étape 7 : Typecheck après tous les patches manuels**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core typecheck
+```
+
+Attendu : uniquement l'erreur sur `fr.json` absent.
+
+- [ ] **Étape 8 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/warn-nodes-count.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/thegreenwebfoundation.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-cookie-size.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-redirects.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-domains.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-fonts.ts \
+        libs/ecoindex-lh-plugin-ts/src/locales/en.json
+git commit -m "feat(i18n): manually patch complex audit files and complete en.json"
+```
+
+---
+
+## Task 6 — Créer `fr.json` avec les traductions complètes
+
+**Fichiers :**
+- Créer : `libs/ecoindex-lh-plugin-ts/src/locales/fr.json`
+
+Les clés de `fr.json` doivent correspondre **exactement** aux clés de `en.json` (généré en Task 4/5). Le format est `"<chemin-relatif-depuis-src>.js | <clé>"`.
+
+**Note sur les clés de `plugin.js` :** Les UIStrings de `plugin.ts` sont enregistrées via `createIcuMessageFn(import.meta.url, UIStrings)`. Le chemin résolu par Lighthouse sera `"plugin.js | groupEcologicTitle"` etc. (chemin relatif depuis le répertoire de locale). Si après build les clés ne correspondent pas, ajuster le préfixe selon la valeur réelle dans le rapport Lighthouse.
+
+- [ ] **Étape 1 : Créer `libs/ecoindex-lh-plugin-ts/src/locales/fr.json`**
+
+```json
+{
+  "plugin.js | groupEcologicTitle": "Résultats Ecoindex",
+  "plugin.js | groupEcologicDescription": "Métriques révélatrices Ecoindex.",
+  "plugin.js | groupTechnicTitle": "Résultats techniques",
+  "plugin.js | groupTechnicDescription": "Métriques techniques.",
+  "plugin.js | groupBpTitle": "#RWEB éco-conception web : 115 bonnes pratiques",
+  "plugin.js | groupBpDescription": "Référentiel \"115 bonnes pratiques\" du CNUMR (Collectif Conception Numérique Responsable).",
+  "plugin.js | groupRgesnTitle": "#RGESN Référentiel Général d'Écoconception de Services Numériques",
+  "plugin.js | groupRgesnDescription": "Référentiel général d'écoconception des services numériques.",
+  "plugin.js | groupOtherTitle": "Autres bonnes pratiques d'écoconception",
+  "plugin.js | groupOtherDescription": "Diverses bonnes pratiques d'écoconception.",
+  "plugin.js | categoryTitle": "Ecoindex",
+
+  "audits/ecoindex-score.js | title": "Métriques Ecoindex.",
+  "audits/ecoindex-score.js | failureTitle": "Ecoindex, votre page pourrait être améliorée.",
+  "audits/ecoindex-grade.js | title": "Note.",
+  "audits/ecoindex-grade.js | failureTitle": "Note, votre page pourrait être améliorée.",
+  "audits/ecoindex-water.js | title": "Consommation d'eau.",
+  "audits/ecoindex-water.js | failureTitle": "Consommation d'eau, votre page consomme trop d'eau.",
+  "audits/ecoindex-ghg.js | title": "Émission de gaz à effet de serre.",
+  "audits/ecoindex-ghg.js | failureTitle": "Émissions de GES, votre page pourrait être améliorée.",
+  "audits/ecoindex-nodes.js | title": "Éléments DOM Ecoindex.",
+  "audits/ecoindex-nodes.js | failureTitle": "Éléments DOM Ecoindex, votre page est trop complexe.",
+  "audits/ecoindex-size.js | title": "Taille de la page.",
+  "audits/ecoindex-size.js | failureTitle": "Taille de la page, votre page est trop lourde.",
+  "audits/ecoindex-requests.js | title": "Nombre de requêtes.",
+  "audits/ecoindex-requests.js | failureTitle": "Trop de requêtes HTTP.",
+  "audits/warn-nodes-count.js | title": "Information ⚠️ : Le nombre de nœuds Ecoindex peut différer du nombre de nœuds Lighthouse.",
+  "audits/warn-nodes-count.js | failureTitle": "Information ⚠️ : Le nombre de nœuds Ecoindex peut différer du nombre de nœuds Lighthouse.",
+
+  "audits/bp/unoptimized-images.js | title": "Ne pas redimensionner les images dans le navigateur",
+  "audits/bp/unoptimized-images.js | failureTitle": "Des images sont redimensionnées dans le navigateur !",
+  "audits/bp/badly-sized-images.js | title": "Ne pas redimensionner les images dans le navigateur",
+  "audits/bp/badly-sized-images.js | failureTitle": "Des images sont redimensionnées dans le navigateur !",
+  "audits/bp/rweb-print-css.js | title": "RWEB_0031 - CSS d'impression",
+  "audits/bp/rweb-print-css.js | failureTitle": "RWEB_0031 - Aucun CSS d'impression implémenté.",
+  "audits/bp/rweb-no-autoplay.js | title": "RWEB_0106 - Pas de lecture automatique vidéo/audio",
+  "audits/bp/rweb-no-autoplay.js | failureTitle": "RWEB_0106 - Lecture automatique vidéo/audio détectée",
+  "audits/bp/rweb-no-social-sdk.js | title": "RWEB_0059 - Pas de boutons officiels de réseaux sociaux",
+  "audits/bp/rweb-no-social-sdk.js | failureTitle": "RWEB_0059 - SDK officiel de réseau social détecté",
+  "audits/bp/rweb-limit-analytics.js | title": "RWEB_0111 - Limiter les outils analytics (≤ 1)",
+  "audits/bp/rweb-limit-analytics.js | failureTitle": "RWEB_0111 - Plusieurs outils analytics détectés",
+  "audits/bp/rweb-limit-domains.js | title": "RWEB_0082 - Limiter les domaines de ressources (≤ 5)",
+  "audits/bp/rweb-limit-domains.js | failureTitle": "RWEB_0082 - Trop de domaines de ressources (> 5)",
+  "audits/bp/rweb-no-redirects.js | title": "RWEB_0112 - Éviter les redirections HTTP (≤ 1)",
+  "audits/bp/rweb-no-redirects.js | failureTitle": "RWEB_0112 - Trop de redirections HTTP (> 1)",
+  "audits/bp/rweb-service-worker.js | title": "RWEB_0060 - Service Worker actif",
+  "audits/bp/rweb-service-worker.js | failureTitle": "RWEB_0060 - Aucun Service Worker actif détecté",
+  "audits/bp/rweb-no-inline-assets.js | title": "RWEB_0042 - Minimiser les ressources inline",
+  "audits/bp/rweb-no-inline-assets.js | failureTitle": "RWEB_0042 - Ressources inline détectées",
+  "audits/bp/rweb-no-canvas.js | title": "RWEB_0055 - Éviter les éléments canvas",
+  "audits/bp/rweb-no-canvas.js | failureTitle": "RWEB_0055 - Éléments canvas détectés",
+  "audits/bp/rweb-limit-fonts.js | title": "RWEB_0032 - Limiter les familles de polices (≤ 2)",
+  "audits/bp/rweb-limit-fonts.js | failureTitle": "RWEB_0032 - Trop de familles de polices externes (> 2)",
+  "audits/bp/rweb-title-meta.js | title": "RWEB_0011 - La page a un titre et une meta description",
+  "audits/bp/rweb-title-meta.js | failureTitle": "RWEB_0011 - Titre ou meta description manquant",
+  "audits/bp/rweb-no-gif.js | title": "RWEB_0099 - Éviter l'utilisation de GIFs",
+  "audits/bp/rweb-no-gif.js | failureTitle": "RWEB_0099 - GIFs détectés",
+  "audits/bp/rweb-no-animations.js | title": "RWEB_0009 - Pas d'éléments animés",
+  "audits/bp/rweb-no-animations.js | failureTitle": "RWEB_0009 - Éléments animés détectés",
+  "audits/bp/rweb-no-carousel.js | title": "RWEB_0010 - Éviter les carrousels",
+  "audits/bp/rweb-no-carousel.js | failureTitle": "RWEB_0010 - Bibliothèque de carrousel détectée",
+  "audits/bp/rweb-no-embedded-docs.js | title": "RWEB_0033 - Pas de documents embarqués",
+  "audits/bp/rweb-no-embedded-docs.js | failureTitle": "RWEB_0033 - Documents embarqués détectés",
+  "audits/bp/rweb-css-containment.js | title": "RWEB_0039 - Utiliser le confinement CSS",
+  "audits/bp/rweb-css-containment.js | failureTitle": "RWEB_0039 - Confinement CSS non vérifié",
+  "audits/bp/rweb-hsts.js | title": "RWEB_0084 - Activer l'en-tête HSTS",
+  "audits/bp/rweb-hsts.js | failureTitle": "RWEB_0084 - En-tête HSTS manquant",
+  "audits/bp/rweb-no-cookie-on-static.js | title": "RWEB_0081 - Pas de cookies sur les ressources statiques",
+  "audits/bp/rweb-no-cookie-on-static.js | failureTitle": "RWEB_0081 - Cookies détectés sur des ressources statiques",
+  "audits/bp/rweb-cache-control.js | title": "RWEB_0075 - Utiliser les en-têtes Cache-Control",
+  "audits/bp/rweb-cache-control.js | failureTitle": "RWEB_0075 - Ressources sans en-tête Cache-Control",
+  "audits/bp/rweb-http-compression.js | title": "RWEB_0076 - Compresser les ressources texte (≥ 95%)",
+  "audits/bp/rweb-http-compression.js | failureTitle": "RWEB_0076 - Ressources texte non compressées",
+  "audits/bp/rweb-uses-http2.js | title": "RWEB_0083 - Utiliser HTTP/2",
+  "audits/bp/rweb-uses-http2.js | failureTitle": "RWEB_0083 - Ressources servies en HTTP/1",
+  "audits/bp/rweb-cookie-size.js | title": "RWEB_0062 - Taille des cookies ≤ 512 octets",
+  "audits/bp/rweb-cookie-size.js | failureTitle": "RWEB_0062 - L'en-tête cookie dépasse 512 octets",
+  "audits/bp/rweb-no-http-errors.js | title": "Éviter les erreurs de requêtes HTTP (4xx/5xx)",
+  "audits/bp/rweb-no-http-errors.js | failureTitle": "Erreurs de requêtes HTTP détectées (4xx/5xx)",
+  "audits/bp/rweb-limit-css-files.js | title": "RWEB_0035 - Limiter les feuilles de style CSS (≤ 7)",
+  "audits/bp/rweb-limit-css-files.js | failureTitle": "RWEB_0035 - Trop de feuilles de style CSS",
+  "audits/bp/rweb-combine-assets.js | title": "RWEB_0078 - Combiner les fichiers CSS et JS (≤ 10 chacun)",
+  "audits/bp/rweb-combine-assets.js | failureTitle": "RWEB_0078 - Trop de fichiers CSS/JS séparés",
+  "audits/bp/rweb-lazy-loading.js | title": "RWEB_0051 - Utiliser le chargement différé pour les images",
+  "audits/bp/rweb-lazy-loading.js | failureTitle": "RWEB_0051 - Images sans chargement différé détectées",
+  "audits/bp/rweb-no-document-write.js | title": "RWEB_0044 - Éviter la manipulation du DOM pendant le parcours",
+  "audits/bp/rweb-no-document-write.js | failureTitle": "RWEB_0044 - Écriture DOM bloquante détectée dans les scripts inline",
+  "audits/bp/rweb-no-hidden-images.js | title": "Éviter de télécharger des images non affichées",
+  "audits/bp/rweb-no-hidden-images.js | failureTitle": "Images téléchargées mais non affichées détectées",
+  "audits/bp/rweb-no-js-errors.js | title": "RWEB_0043 - Pas d'erreurs JavaScript dans la console",
+  "audits/bp/rweb-no-js-errors.js | failureTitle": "RWEB_0043 - Erreurs JavaScript détectées",
+  "audits/bp/rweb-no-plugins.js | title": "Ne pas utiliser de plugins navigateur (Flash, Silverlight, Java)",
+  "audits/bp/rweb-no-plugins.js | failureTitle": "Plugin navigateur détecté (Flash, Silverlight, Java)",
+  "audits/bp/rweb-minification.js | title": "RWEB_0077 - Minifier les CSS et JS inline",
+  "audits/bp/rweb-minification.js | failureTitle": "RWEB_0077 - CSS/JS inline non minifiés détectés",
+  "audits/bp/rweb-optimize-svg.js | title": "RWEB_0100 - Optimiser les fichiers SVG",
+  "audits/bp/rweb-optimize-svg.js | failureTitle": "RWEB_0100 - Fichiers SVG volumineux détectés (probablement non optimisés)",
+  "audits/bp/rweb-prefer-css.js | title": "RWEB_0037 - Préférer CSS aux images pour les éléments d'interface",
+  "audits/bp/rweb-prefer-css.js | failureTitle": "RWEB_0037 - Images utilisées pour des icônes d'interface (préférer CSS)",
+  "audits/bp/rweb-no-bitmap-ui.js | title": "RWEB_0038 - Éviter les images bitmap pour les éléments d'interface",
+  "audits/bp/rweb-no-bitmap-ui.js | failureTitle": "RWEB_0038 - Images bitmap dans des conteneurs d'interface détectées",
+  "audits/bp/rweb-no-unused-code.js | title": "Éviter le code inutilisé",
+  "audits/bp/rweb-no-unused-code.js | failureTitle": "Code inutilisé détecté",
+  "audits/bp/rweb-css-splitting.js | title": "RWEB_0036 - Séparer le CSS par contexte média",
+  "audits/bp/rweb-css-splitting.js | failureTitle": "RWEB_0036 - CSS non séparé par contexte média",
+  "audits/bp/thegreenwebfoundation.js | title": "The Green Web Foundation",
+  "audits/bp/thegreenwebfoundation.js | failureTitle": "Votre site web n'est pas hébergé chez un hébergeur web vert."
+}
+```
+
+- [ ] **Étape 2 : Vérifier que toutes les clés de `en.json` ont un équivalent dans `fr.json`**
+
+```bash
+node -e "
+const en = JSON.parse(require('fs').readFileSync('libs/ecoindex-lh-plugin-ts/src/locales/en.json', 'utf-8'))
+const fr = JSON.parse(require('fs').readFileSync('libs/ecoindex-lh-plugin-ts/src/locales/fr.json', 'utf-8'))
+const missing = Object.keys(en).filter(k => !(k in fr))
+if (missing.length) { console.log('Missing in fr.json:', missing); process.exit(1) }
+else console.log('✅ All en.json keys present in fr.json')
+"
+```
+
+Si des clés sont manquantes, les ajouter avec une traduction FR (ou copier la valeur EN temporairement).
+
+- [ ] **Étape 3 : Typecheck complet (fr.json maintenant présent)**
+
+```bash
+pnpm --filter lighthouse-plugin-ecoindex-core typecheck
+```
+
+Attendu : aucune erreur.
+
+- [ ] **Étape 4 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/locales/fr.json
+git commit -m "feat(i18n): add complete fr.json with all French translations"
+```
+
+---
+
+## Task 7 — Build, pre-commit checks et changeset
+
+- [ ] **Étape 1 : Build complet**
+
+```bash
+pnpm build
+```
+
+Attendu : aucune erreur de compilation.
+
+- [ ] **Étape 2 : Pre-commit checks**
+
+```bash
+pnpm format:check && pnpm typecheck && pnpm lint && pnpm typecheck:strict
+```
+
+Si `format:check` échoue, lancer d'abord `pnpm format:write`.
+
+- [ ] **Étape 3 : Créer le changeset**
+
+Créer `.changeset/i18n-plugin-strings.md` :
+
+```markdown
+---
+"lighthouse-plugin-ecoindex-core": minor
+---
+
+feat(i18n): instrument all audit files with UIStrings and createIcuMessageFn, add en.json and fr.json locales, register FR locale in plugin.ts
+```
+
+- [ ] **Étape 4 : Commit final**
+
+```bash
+git add .changeset/i18n-plugin-strings.md
+git commit -m "chore(changeset): add changeset for i18n phase 1"
+```

--- a/.superpowers/plans/2026-05-10-i18n-phase2-validation.md
+++ b/.superpowers/plans/2026-05-10-i18n-phase2-validation.md
@@ -1,0 +1,297 @@
+# i18n Phase 2 — Validation (Coverage + E2E)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Valider que l'infrastructure i18n est complète et correcte : script `check-i18n-coverage.ts` qui vérifie que chaque clé EN a une traduction FR, intégré comme `pnpm check:i18n` dans la CI, suivi d'un test E2E pour confirmer que `--lang fr` produit un rapport Lighthouse avec les strings françaises.
+
+**Architecture:** Script Node.js standalone (`tsx`) qui lit `en.json` et `fr.json`, compare les clés, et sort avec exit code 1 si des traductions FR sont absentes ou vides. Le test E2E construit le CLI, lance un `collect` sur une URL publique avec `--lang fr`, et vérifie que le rapport JSON contient des strings françaises dans les audits du plugin.
+
+**Prérequis :** Plans A et B complétés (lang propagation + plugin strings instrumentés + fr.json créé).
+
+**Tech Stack:** TypeScript, tsx, Node.js 20+, pnpm.
+
+---
+
+## Carte des fichiers
+
+| Fichier | Changement |
+|---------|------------|
+| `scripts/check-i18n-coverage.ts` | Nouveau script de vérification couverture |
+| `package.json` (racine) | Ajout `"check:i18n"` dans scripts |
+
+---
+
+## Task 1 — Script `check-i18n-coverage.ts`
+
+**Fichiers :**
+- Créer : `scripts/check-i18n-coverage.ts`
+
+- [ ] **Étape 1 : Créer le script**
+
+Créer `scripts/check-i18n-coverage.ts` avec ce contenu exact :
+
+```ts
+#!/usr/bin/env tsx
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const LOCALES_DIR = path.join(
+  __dirname,
+  '../libs/ecoindex-lh-plugin-ts/src/locales',
+)
+
+function main() {
+  const enPath = path.join(LOCALES_DIR, 'en.json')
+  const frPath = path.join(LOCALES_DIR, 'fr.json')
+
+  if (!fs.existsSync(enPath)) {
+    console.error('❌ en.json not found. Run pnpm i18n:extract first.')
+    process.exit(1)
+  }
+  if (!fs.existsSync(frPath)) {
+    console.error('❌ fr.json not found. Create fr.json first.')
+    process.exit(1)
+  }
+
+  const en: Record<string, string> = JSON.parse(
+    fs.readFileSync(enPath, 'utf-8'),
+  )
+  const fr: Record<string, string> = JSON.parse(
+    fs.readFileSync(frPath, 'utf-8'),
+  )
+
+  const missing = Object.keys(en).filter(k => !fr[k] || fr[k] === '')
+  const extra = Object.keys(fr).filter(k => !en[k])
+
+  console.log('\n📊 i18n coverage check')
+  console.log(`   EN keys: ${Object.keys(en).length}`)
+  console.log(`   FR keys: ${Object.keys(fr).length}`)
+
+  if (extra.length > 0) {
+    console.warn('\n⚠️  Extra keys in FR (not in EN):')
+    extra.forEach(k => console.warn(`   - ${k}`))
+  }
+
+  if (missing.length > 0) {
+    console.error(
+      `\n❌ Missing or empty translations in FR (${missing.length}):`,
+    )
+    missing.forEach(k => console.error(`   - ${k}  [EN: "${en[k]}"]`))
+    console.error(
+      '\nFix these keys in libs/ecoindex-lh-plugin-ts/src/locales/fr.json',
+    )
+    process.exit(1)
+  }
+
+  console.log(
+    `\n✅ 100% coverage — all ${Object.keys(en).length} EN keys are translated in FR\n`,
+  )
+}
+
+main()
+```
+
+- [ ] **Étape 2 : Tester le script manuellement (avant d'ajouter au package.json)**
+
+```bash
+tsx scripts/check-i18n-coverage.ts
+```
+
+Attendu : `✅ 100% coverage — all N EN keys are translated in FR`
+
+Si des clés manquent → les ajouter dans `libs/ecoindex-lh-plugin-ts/src/locales/fr.json` avant de continuer.
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+git add scripts/check-i18n-coverage.ts
+git commit -m "feat(i18n): add check-i18n-coverage script"
+```
+
+---
+
+## Task 2 — Ajouter `check:i18n` dans `package.json`
+
+**Fichiers :**
+- Modifier : `package.json` (racine)
+
+- [ ] **Étape 1 : Ajouter le script après `refs:update:version`**
+
+Dans `package.json` racine, section `scripts`, après :
+```json
+"refs:update:version": "tsx scripts/generate-refs-urls.ts -- --version"
+```
+
+Ajouter (virgule sur la ligne précédente si besoin) :
+```json
+"refs:update:version": "tsx scripts/generate-refs-urls.ts -- --version",
+"i18n:extract": "tsx scripts/i18n-extract-patch.ts",
+"check:i18n": "tsx scripts/check-i18n-coverage.ts"
+```
+
+Note : `i18n:extract` a déjà été ajouté en Plan B. Si c'est déjà présent, ajouter uniquement `check:i18n`.
+
+- [ ] **Étape 2 : Vérifier que le script se lance via pnpm**
+
+```bash
+pnpm check:i18n
+```
+
+Attendu : `✅ 100% coverage — all N EN keys are translated in FR`
+
+- [ ] **Étape 3 : Commit**
+
+```bash
+git add package.json
+git commit -m "feat(i18n): add check:i18n script to package.json"
+```
+
+---
+
+## Task 3 — Pre-commit checks globaux
+
+- [ ] **Étape 1 : Format**
+
+```bash
+pnpm format:check
+```
+
+Attendu : aucune erreur. Si erreurs de format → `pnpm format:write` puis re-vérifier.
+
+- [ ] **Étape 2 : Typecheck**
+
+```bash
+pnpm typecheck
+pnpm typecheck:strict
+```
+
+Attendu : aucune erreur dans les deux commandes.
+
+- [ ] **Étape 3 : Lint**
+
+```bash
+pnpm lint
+```
+
+Attendu : aucune erreur.
+
+- [ ] **Étape 4 : Build complet**
+
+```bash
+pnpm build
+```
+
+Attendu : tous les packages compilent sans erreur.
+
+- [ ] **Étape 5 : Commit si des corrections ont été nécessaires**
+
+Si `format:write` a modifié des fichiers :
+```bash
+git add -p
+git commit -m "style(i18n): fix formatting after i18n instrumentation"
+```
+
+---
+
+## Task 4 — Test E2E : `--lang fr` dans le CLI
+
+Ce test vérifie que la chaîne complète fonctionne : `--lang fr` → `settings.locale = 'fr'` → Lighthouse retourne les strings françaises du plugin.
+
+- [ ] **Étape 1 : Vérifier que `--lang` est présent dans l'aide CLI**
+
+```bash
+node apps/ecoindex-lh-cli/dist/bin.js collect --help | grep lang
+```
+
+Attendu : une ligne mentionnant `--lang` avec `choices: "en", "fr"`.
+
+Si le dist est absent : `pnpm --filter lighthouse-plugin-ecoindex-cli build` d'abord.
+
+- [ ] **Étape 2 : Lancer un collect `--lang fr` sur une URL publique**
+
+```bash
+node apps/ecoindex-lh-cli/dist/bin.js collect \
+  --url https://www.ecoindex.fr/ \
+  --lang fr \
+  --output-path /tmp/ecoindex-i18n-test \
+  --json
+```
+
+Attendu : le script s'exécute jusqu'à la fin sans erreur TypeScript/runtime.
+
+Note : nécessite Chromium installé. Si le navigateur manque, exécuter d'abord :
+```bash
+node apps/ecoindex-lh-cli/dist/bin.js install-browser
+```
+
+- [ ] **Étape 3 : Vérifier les strings françaises dans le rapport JSON**
+
+```bash
+find /tmp/ecoindex-i18n-test -name "*.json" | head -1 | xargs node -e "
+  const r = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf-8'))
+  const audits = r.lhr?.audits ?? {}
+  const ecoScore = audits['eco-index-score']
+  console.log('title:', ecoScore?.title)
+  console.log('description:', ecoScore?.description?.slice(0, 80))
+" 2>/dev/null || echo "Rapport JSON introuvable — vérifier le --output-path"
+```
+
+Attendu : `title` affiche la valeur française (ex. `"Métriques Ecoindex révélatrices."` ou équivalent défini dans `fr.json`).
+
+Si la valeur est encore en anglais : vérifier que `registerLocaleData('fr', frLocale)` est bien présent dans le `plugin.ts` buildé (`apps/ecoindex-lh-cli/dist/` ou `libs/ecoindex-lh-plugin-ts/dist/`).
+
+- [ ] **Étape 4 : Nettoyer les fichiers de test**
+
+```bash
+trash /tmp/ecoindex-i18n-test
+```
+
+---
+
+## Task 5 — Changeset
+
+- [ ] **Étape 1 : Créer le fichier changeset**
+
+Créer `.changeset/<nom-aleatoire>.md` (remplacer `<nom-aleatoire>` par un nom court, ex. `i18n-coverage`) :
+
+```markdown
+---
+"lighthouse-plugin-ecoindex-plugin": minor
+---
+
+feat(i18n): add check:i18n coverage script and validate EN/FR translation completeness
+```
+
+Note : si le package plugin s'appelle `lighthouse-plugin-ecoindex` (vérifier dans `libs/ecoindex-lh-plugin-ts/package.json`), utiliser ce nom exact.
+
+- [ ] **Étape 2 : Vérifier le nom exact du package plugin**
+
+```bash
+node -e "console.log(require('./libs/ecoindex-lh-plugin-ts/package.json').name)"
+```
+
+Mettre à jour le nom dans le changeset si différent de `lighthouse-plugin-ecoindex-plugin`.
+
+- [ ] **Étape 3 : Commit final**
+
+```bash
+git add .changeset/
+git commit -m "chore(changeset): add changeset for i18n phase 2 validation"
+```
+
+---
+
+## Résumé des 3 plans i18n
+
+| Plan | Phase | Packages touchés | Commits |
+|------|-------|-----------------|---------|
+| A — Phase 0 | Propagation `lang` | cli, courses | 4 commits + changeset |
+| B — Phase 1 | Plugin strings | plugin-ts, scripts | 7 commits + changeset |
+| C — Phase 2 | Validation | scripts, package.json | 3 commits + changeset |
+
+Critères de succès finaux :
+- `pnpm check:i18n` passe (0 clé manquante)
+- `collect --lang fr` produit des strings françaises dans le rapport
+- `collect` sans `--lang` produit des strings anglaises (aucune régression)

--- a/.superpowers/plans/2026-05-25-audit-details-tables.md
+++ b/.superpowers/plans/2026-05-25-audit-details-tables.md
@@ -1,0 +1,1117 @@
+# Audit Details Tables Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter une table `details` Lighthouse dans 12 audits BP pour exposer les éléments problématiques (domaines, URLs, sélecteurs CSS, extraits de code) plutôt qu'un simple compteur.
+
+**Architecture:** Extension du `BPGatherer` pour retourner des tableaux d'objets à la place de compteurs entiers (Groupe 1 — 4 audits), puis ajout direct de `details` dans les 8 audits du Groupe 2 qui ont déjà les données disponibles. Le type `BPGathererResult` est mis à jour en premier pour faire échouer le typecheck sur les 4 audits consommateurs, confirmant les "tests rouges".
+
+**Tech Stack:** TypeScript, Lighthouse Audit API (`LH.Audit.Details.Table`), `createIcuMessageFn` pour i18n des labels de colonnes, `pnpm typecheck:strict` comme vérification de compilation.
+
+---
+
+## Fichiers modifiés
+
+| Fichier                                                                | Changement                                                             |
+| ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `libs/ecoindex-lh-plugin-ts/src/types/index.d.ts`                      | Remplace les compteurs de `BPGathererResult` par des tableaux d'objets |
+| `libs/ecoindex-lh-plugin-ts/src/gatherers/bp-gatherer.ts`              | Implémente `collectBPData()` avec les nouveaux tableaux                |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-autoplay.ts`         | Utilise `autoplayDetails` + table                                      |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-canvas.ts`           | Utilise `canvasDetails` + table                                        |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-inline-assets.ts`    | Utilise `inlineScriptDetails`/`inlineStyleDetails` + table             |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-animations.ts`       | Utilise `animatedElementDetails` + table                               |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-domains.ts`       | Ajoute table des domaines                                              |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-fonts.ts`         | Ajoute table des domaines de polices                                   |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-analytics.ts`     | Ajoute table des domaines analytics                                    |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-gif.ts`              | Ajoute table des URLs GIF réseau                                       |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-redirects.ts`        | Ajoute table URL + code HTTP                                           |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-cookie-on-static.ts` | Ajoute table des URLs avec cookie                                      |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-social-sdk.ts`       | Ajoute table des URLs SDK                                              |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-carousel.ts`         | Ajoute table des URLs carousel                                         |
+
+---
+
+## Task 1: Créer la branche de travail
+
+**Files:** aucun
+
+- [ ] **Step 1: Créer et basculer sur la branche**
+
+```bash
+git checkout -b feat/audit-details-tables
+```
+
+- [ ] **Step 2: Vérifier**
+
+```bash
+git branch --show-current
+```
+
+Expected: `feat/audit-details-tables`
+
+---
+
+## Task 2: Mettre à jour BPGathererResult (test rouge)
+
+Cette modification supprime les champs entiers (`autoplaying`, `canvasCount`, `inlineScripts`, `inlineStyles`, `animatedElements`) et les remplace par des tableaux. Le typecheck échouera sur 4 audits — c'est intentionnel (TDD : on voit les tests rouges avant d'implémenter).
+
+**Files:**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/types/index.d.ts`
+
+- [ ] **Step 1: Remplacer l'interface BPGathererResult**
+
+Remplacer dans `libs/ecoindex-lh-plugin-ts/src/types/index.d.ts` :
+
+```typescript
+// AVANT
+export interface BPGathererResult {
+  autoplaying: number
+  serviceWorkerActive: boolean
+  canvasCount: number
+  inlineScripts: number
+  inlineStyles: number
+  animatedElements: number
+}
+
+// APRÈS
+export interface BPGathererResult {
+  serviceWorkerActive: boolean
+  inlineScriptDetails: { snippet: string }[]
+  inlineStyleDetails: { snippet: string }[]
+  animatedElementDetails: { selector: string; property: string }[]
+  autoplayDetails: { selector: string; src: string }[]
+  canvasDetails: { selector: string }[]
+}
+```
+
+- [ ] **Step 2: Vérifier que le typecheck échoue sur 4 audits**
+
+```bash
+pnpm typecheck:strict 2>&1 | grep -E "rweb-no-(autoplay|canvas|inline-assets|animations)"
+```
+
+Expected: 4 lignes d'erreur mentionnant les 4 audits. Si 0 erreur, vérifier que le fichier a bien été modifié.
+
+---
+
+## Task 3: Implémenter le nouveau BPGatherer
+
+**Files:**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/gatherers/bp-gatherer.ts`
+
+- [ ] **Step 1: Réécrire le fichier complet**
+
+```typescript
+import * as LH from 'lighthouse/types/lh.js'
+
+import { Gatherer } from 'lighthouse'
+
+class BPGatherer extends Gatherer {
+  meta: LH.Gatherer.GathererMeta = {
+    supportedModes: ['navigation', 'timespan', 'snapshot'],
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getArtifact(passContext: { driver: any }) {
+    const { driver } = passContext
+    const { executionContext } = driver
+
+    function collectBPData() {
+      if (typeof document === 'undefined') {
+        return {
+          serviceWorkerActive: false,
+          inlineScriptDetails: [],
+          inlineStyleDetails: [],
+          animatedElementDetails: [],
+          autoplayDetails: [],
+          canvasDetails: [],
+        }
+      }
+
+      const SNIPPET_LEN = 120
+
+      function buildSelector(el) {
+        let sel = el.tagName.toLowerCase()
+        if (el.id) sel += `#${el.id}`
+        if (el.classList.length > 0)
+          sel += '.' + Array.from(el.classList).join('.')
+        return sel
+      }
+
+      const serviceWorkerActive = Boolean(
+        'serviceWorker' in navigator &&
+        navigator.serviceWorker &&
+        navigator.serviceWorker.controller,
+      )
+
+      const inlineScriptDetails = Array.from(
+        document.querySelectorAll('script:not([src])'),
+      )
+        .filter(
+          s =>
+            s.getAttribute('type') !== 'application/ld+json' &&
+            (s.textContent || '').trim().length > 0,
+        )
+        .map(s => ({
+          snippet: (s.textContent || '').trim().slice(0, SNIPPET_LEN),
+        }))
+
+      const inlineStyleDetails = Array.from(document.querySelectorAll('style'))
+        .filter(s => (s.textContent || '').trim().length > 0)
+        .map(s => ({
+          snippet: (s.textContent || '').trim().slice(0, SNIPPET_LEN),
+        }))
+
+      const animatedElementDetails = []
+      for (const el of Array.from(document.querySelectorAll('*'))) {
+        const cs = window.getComputedStyle(el)
+        const hasAnimation =
+          cs.animationName !== 'none' && cs.animationName !== ''
+        const hasTransition =
+          cs.transitionProperty !== 'none' &&
+          cs.transitionProperty !== '' &&
+          cs.transitionDuration !== '0s'
+        if (hasAnimation || hasTransition) {
+          const property = hasAnimation
+            ? `animation: ${cs.animationName}`
+            : `transition: ${cs.transitionProperty}`
+          animatedElementDetails.push({ selector: buildSelector(el), property })
+        }
+      }
+
+      const autoplayDetails = Array.from(
+        document.querySelectorAll(
+          'video[autoplay], audio[autoplay], video[preload="auto"], audio[preload="auto"]',
+        ),
+      ).map(el => ({
+        selector: buildSelector(el),
+        src: el.getAttribute('src') || '',
+      }))
+
+      const canvasDetails = Array.from(document.querySelectorAll('canvas')).map(
+        el => ({ selector: buildSelector(el) }),
+      )
+
+      return {
+        serviceWorkerActive,
+        inlineScriptDetails,
+        inlineStyleDetails,
+        animatedElementDetails: animatedElementDetails.slice(0, 50),
+        autoplayDetails,
+        canvasDetails,
+      }
+    }
+
+    const results = await executionContext.evaluate(collectBPData, { args: [] })
+    return results
+  }
+}
+
+export default BPGatherer
+```
+
+---
+
+## Task 4: Mettre à jour rweb-no-autoplay
+
+**Files:**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-autoplay.ts`
+
+- [ ] **Step 1: Réécrire le fichier complet**
+
+```typescript
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import type { BPArtifacts } from '../../types/index.js'
+import { Audit } from 'lighthouse'
+import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'
+
+const UIStrings = {
+  title: 'RWEB_0106 - No video/audio autoplay',
+  failureTitle: 'RWEB_0106 - Autoplay video/audio detected',
+  description:
+    'Avoid autoplay on video and audio elements. [See RWEB_0106](https://rweb.greenit.fr/es/fiches/RWEB_0106-evitar-la-reproduccion-y-carga-automatica-de-videos-y-sonidos)',
+  displayValue: '{count} autoplay element(s)',
+  colLabelElement: 'Element',
+  colLabelSrc: 'Source',
+}
+const str_ = createIcuMessageFn('audits/bp/rweb-no-autoplay.js', UIStrings)
+
+class BPRwebNoAutoplay extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-no-autoplay',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      requiredArtifacts: ['BPGatherer'] as unknown as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static audit(artifacts: LH.Artifacts & BPArtifacts) {
+    const { autoplayDetails } = artifacts.BPGatherer
+    const count = autoplayDetails.length
+
+    return {
+      score: count === 0 ? 1 : 0,
+      displayValue: str_(UIStrings.displayValue, { count }),
+      numericValue: count,
+      numericUnit: 'unitless' as
+        | 'unitless'
+        | 'byte'
+        | 'millisecond'
+        | 'element',
+      ...(count > 0 && {
+        details: {
+          type: 'table' as const,
+          headings: [
+            {
+              key: 'selector',
+              label: str_(UIStrings.colLabelElement),
+              valueType: 'text' as const,
+            },
+            {
+              key: 'src',
+              label: str_(UIStrings.colLabelSrc),
+              valueType: 'text' as const,
+            },
+          ],
+          items: autoplayDetails.map(d => ({
+            selector: d.selector,
+            src: d.src || '—',
+          })),
+        } as LH.Audit.Details.Table,
+      }),
+    }
+  }
+}
+
+export default BPRwebNoAutoplay
+```
+
+---
+
+## Task 5: Mettre à jour rweb-no-canvas
+
+**Files:**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-canvas.ts`
+
+- [ ] **Step 1: Réécrire le fichier complet**
+
+```typescript
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import type { BPArtifacts } from '../../types/index.js'
+import { Audit } from 'lighthouse'
+import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'
+
+const UIStrings = {
+  title: 'RWEB_0055 - Avoid canvas elements',
+  failureTitle: 'RWEB_0055 - Canvas elements detected',
+  description:
+    'Minimize the use of canvas elements. [See RWEB_0055](https://rweb.greenit.fr/en/fiches/RWEB_0055-limit-canvas-use)',
+  displayValuePass: 'No canvas elements',
+  displayValueFail: '{count} canvas element(s) found',
+  colLabelElement: 'Element',
+}
+const str_ = createIcuMessageFn('audits/bp/rweb-no-canvas.js', UIStrings)
+
+class BPRwebNoCanvas extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-no-canvas',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      requiredArtifacts: ['BPGatherer'] as unknown as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static audit(artifacts: LH.Artifacts & BPArtifacts) {
+    const { canvasDetails } = artifacts.BPGatherer
+    const count = canvasDetails.length
+
+    return {
+      score: count === 0 ? 1 : 0,
+      displayValue:
+        count === 0
+          ? str_(UIStrings.displayValuePass)
+          : str_(UIStrings.displayValueFail, { count }),
+      numericValue: count,
+      numericUnit: 'unitless' as
+        | 'unitless'
+        | 'byte'
+        | 'millisecond'
+        | 'element',
+      ...(count > 0 && {
+        details: {
+          type: 'table' as const,
+          headings: [
+            {
+              key: 'selector',
+              label: str_(UIStrings.colLabelElement),
+              valueType: 'text' as const,
+            },
+          ],
+          items: canvasDetails.map(d => ({ selector: d.selector })),
+        } as LH.Audit.Details.Table,
+      }),
+    }
+  }
+}
+
+export default BPRwebNoCanvas
+```
+
+---
+
+## Task 6: Mettre à jour rweb-no-inline-assets
+
+**Files:**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-inline-assets.ts`
+
+- [ ] **Step 1: Réécrire le fichier complet**
+
+```typescript
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import type { BPArtifacts } from '../../types/index.js'
+import { Audit } from 'lighthouse'
+import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'
+
+const UIStrings = {
+  title: 'RWEB_0042 - Minimize inline assets',
+  failureTitle: 'RWEB_0042 - Inline assets detected',
+  description:
+    'Minimize the use of inline scripts and styles. [See RWEB_0042](https://rweb.greenit.fr/en/fiches/RWEB_0042-externalize-css-and-javascript)',
+  displayValuePass: 'No inline assets',
+  displayValueFail: '{count} inline asset(s) found',
+  colLabelType: 'Type',
+  colLabelSnippet: 'Snippet',
+}
+const str_ = createIcuMessageFn('audits/bp/rweb-no-inline-assets.js', UIStrings)
+
+class BPRwebNoInlineAssets extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-no-inline-assets',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      requiredArtifacts: ['BPGatherer'] as unknown as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static audit(artifacts: LH.Artifacts & BPArtifacts) {
+    const { inlineScriptDetails, inlineStyleDetails } = artifacts.BPGatherer
+    const totalInlineAssets =
+      inlineScriptDetails.length + inlineStyleDetails.length
+
+    const items = [
+      ...inlineScriptDetails.map(d => ({ type: 'script', snippet: d.snippet })),
+      ...inlineStyleDetails.map(d => ({ type: 'style', snippet: d.snippet })),
+    ]
+
+    return {
+      score: totalInlineAssets <= 2 ? 1 : 0,
+      displayValue:
+        totalInlineAssets === 0
+          ? str_(UIStrings.displayValuePass)
+          : str_(UIStrings.displayValueFail, { count: totalInlineAssets }),
+      numericValue: totalInlineAssets,
+      numericUnit: 'unitless' as
+        | 'unitless'
+        | 'byte'
+        | 'millisecond'
+        | 'element',
+      ...(totalInlineAssets > 0 && {
+        details: {
+          type: 'table' as const,
+          headings: [
+            {
+              key: 'type',
+              label: str_(UIStrings.colLabelType),
+              valueType: 'text' as const,
+            },
+            {
+              key: 'snippet',
+              label: str_(UIStrings.colLabelSnippet),
+              valueType: 'text' as const,
+            },
+          ],
+          items,
+        } as LH.Audit.Details.Table,
+      }),
+    }
+  }
+}
+
+export default BPRwebNoInlineAssets
+```
+
+---
+
+## Task 7: Mettre à jour rweb-no-animations
+
+**Files:**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-animations.ts`
+
+- [ ] **Step 1: Réécrire le fichier complet**
+
+```typescript
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import type { BPArtifacts } from '../../types/index.js'
+import { Audit } from 'lighthouse'
+import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'
+
+const UIStrings = {
+  title: 'RWEB_0009 - No animated elements',
+  failureTitle: 'RWEB_0009 - Animated elements detected',
+  description:
+    'Avoid animations and transitions to reduce CPU and battery usage. [See RWEB_0009](https://rweb.greenit.fr/en/fiches/RWEB_0009-avoid-javascriptcss-animations)',
+  displayValuePass: 'No animated elements',
+  displayValueFail: '{count} animated element(s) found',
+  colLabelElement: 'Element',
+  colLabelProperty: 'Property',
+}
+const str_ = createIcuMessageFn('audits/bp/rweb-no-animations.js', UIStrings)
+
+class BPRwebNoAnimations extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-no-animations',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      requiredArtifacts: ['BPGatherer'] as unknown as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static audit(artifacts: LH.Artifacts & BPArtifacts): LH.Audit.Product {
+    const { animatedElementDetails } = artifacts.BPGatherer
+    const count = animatedElementDetails.length
+
+    return {
+      score: count === 0 ? 1 : 0,
+      displayValue:
+        count === 0
+          ? str_(UIStrings.displayValuePass)
+          : str_(UIStrings.displayValueFail, { count }),
+      numericValue: count,
+      numericUnit: 'unitless' as
+        | 'unitless'
+        | 'byte'
+        | 'millisecond'
+        | 'element',
+      ...(count > 0 && {
+        details: {
+          type: 'table' as const,
+          headings: [
+            {
+              key: 'selector',
+              label: str_(UIStrings.colLabelElement),
+              valueType: 'text' as const,
+            },
+            {
+              key: 'property',
+              label: str_(UIStrings.colLabelProperty),
+              valueType: 'text' as const,
+            },
+          ],
+          items: animatedElementDetails.map(d => ({
+            selector: d.selector,
+            property: d.property,
+          })),
+        } as LH.Audit.Details.Table,
+      }),
+    }
+  }
+}
+
+export default BPRwebNoAnimations
+```
+
+- [ ] **Step 2: Vérifier que le typecheck passe sur le Groupe 1**
+
+```bash
+pnpm typecheck:strict 2>&1 | grep -E "rweb-no-(autoplay|canvas|inline-assets|animations)"
+```
+
+Expected: aucune ligne d'erreur. Si des erreurs persistent, corriger avant de continuer.
+
+- [ ] **Step 3: Commit Groupe 1**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/gatherers/bp-gatherer.ts \
+        libs/ecoindex-lh-plugin-ts/src/types/index.d.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-autoplay.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-canvas.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-inline-assets.ts \
+        libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-animations.ts
+git commit -m "feat(bp): extend BPGatherer to expose element details for 4 audits"
+```
+
+---
+
+## Task 8: Ajouter table à rweb-limit-domains
+
+**Files:**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-domains.ts`
+
+- [ ] **Step 1: Ajouter `colLabelDomain` dans UIStrings et la table dans le retour**
+
+Ajouter dans `UIStrings` :
+
+```typescript
+colLabelDomain: 'Domain',
+```
+
+Remplacer le bloc `return` final par :
+
+```typescript
+return {
+  score: count <= MAX_DOMAINS ? 1 : 0,
+  displayValue: str_(UIStrings.displayValue, { count }),
+  numericValue: count,
+  numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+  details: {
+    type: 'table' as const,
+    headings: [
+      {
+        key: 'domain',
+        label: str_(UIStrings.colLabelDomain),
+        valueType: 'text' as const,
+      },
+    ],
+    items: [...domains].map(domain => ({ domain })),
+  } as LH.Audit.Details.Table,
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-domains.ts
+git commit -m "feat(bp): add domain list table to rweb-limit-domains"
+```
+
+---
+
+## Task 9: Ajouter table à rweb-limit-fonts
+
+**Files:**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-fonts.ts`
+
+- [ ] **Step 1: Ajouter `colLabelDomain` dans UIStrings et la table dans le retour**
+
+Ajouter dans `UIStrings` :
+
+```typescript
+colLabelDomain: 'Font domain',
+```
+
+Remplacer le bloc `return` final par :
+
+```typescript
+return {
+  score: count <= MAX_FONT_FAMILIES ? 1 : 0,
+  displayValue: str_(UIStrings.displayValue, { count }),
+  numericValue: count,
+  numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+  details: {
+    type: 'table' as const,
+    headings: [
+      {
+        key: 'domain',
+        label: str_(UIStrings.colLabelDomain),
+        valueType: 'text' as const,
+      },
+    ],
+    items: [...fontFamilies].map(domain => ({ domain })),
+  } as LH.Audit.Details.Table,
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-fonts.ts
+git commit -m "feat(bp): add font domain table to rweb-limit-fonts"
+```
+
+---
+
+## Task 10: Ajouter table à rweb-limit-analytics
+
+**Files:**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-analytics.ts`
+
+- [ ] **Step 1: Ajouter `colLabelDomain` dans UIStrings et la table dans le retour**
+
+Ajouter dans `UIStrings` :
+
+```typescript
+colLabelDomain: 'Analytics domain',
+```
+
+Remplacer le bloc `return` final par :
+
+```typescript
+return {
+  score: count <= 1 ? 1 : 0,
+  displayValue: str_(UIStrings.displayValue, { count }),
+  numericValue: count,
+  numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+  details: {
+    type: 'table' as const,
+    headings: [
+      {
+        key: 'domain',
+        label: str_(UIStrings.colLabelDomain),
+        valueType: 'text' as const,
+      },
+    ],
+    items: [...matchedDomains].map(domain => ({ domain })),
+  } as LH.Audit.Details.Table,
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-analytics.ts
+git commit -m "feat(bp): add analytics domain table to rweb-limit-analytics"
+```
+
+---
+
+## Task 11: Ajouter table à rweb-no-gif
+
+**Files:**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-gif.ts`
+
+- [ ] **Step 1: Refactoriser pour collecter les URLs réseau séparément + ajouter la table**
+
+Le fichier actuel mélange la détection réseau et HTML dans un seul compteur. On doit séparer les URLs réseau (listables) des matches HTML (seulement pour le score).
+
+Réécrire le fichier complet :
+
+```typescript
+import * as LH from 'lighthouse/types/lh.js'
+
+import {
+  ContextualBaseArtifacts,
+  GathererArtifacts,
+  UniversalBaseArtifacts,
+} from 'lighthouse/types/artifacts.js'
+
+import { Audit, NetworkRecords } from 'lighthouse'
+import { NetworkRequest } from 'lighthouse/core/lib/network-request.js'
+import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'
+
+const UIStrings = {
+  title: 'RWEB_0099 - Avoid using GIFs',
+  failureTitle: 'RWEB_0099 - GIFs detected',
+  description:
+    'Avoid using GIFs for animations or images; use modern formats instead. [See RWEB_0099](https://rweb.greenit.fr/en/fiches/RWEB_0099-limit-the-use-of-animated-gif)',
+  displayValuePass: 'No GIFs detected',
+  displayValueFail: '{count} GIF(s) detected',
+  colLabelUrl: 'GIF URL',
+}
+const str_ = createIcuMessageFn('audits/bp/rweb-no-gif.js', UIStrings)
+
+class BPRwebNoGif extends Audit {
+  static get meta() {
+    return {
+      id: 'rweb-no-gif',
+      title: str_(UIStrings.title),
+      failureTitle: str_(UIStrings.failureTitle),
+      description: str_(UIStrings.description),
+      requiredArtifacts: ['DevtoolsLog', 'MainDocumentContent'] as (
+        | keyof UniversalBaseArtifacts
+        | keyof ContextualBaseArtifacts
+        | keyof GathererArtifacts
+      )[],
+    }
+  }
+
+  static async audit(artifacts: LH.Artifacts, context: LH.Audit.Context) {
+    const networkRecords = await NetworkRecords.request(
+      artifacts.DevtoolsLog,
+      context,
+    )
+    const html = artifacts.MainDocumentContent || ''
+
+    const gifRecords: string[] = []
+    for (const record of networkRecords) {
+      if (NetworkRequest.isNonNetworkRequest(record)) continue
+      if (record.url.toLowerCase().endsWith('.gif')) {
+        gifRecords.push(record.url)
+      }
+    }
+
+    // Count inline <img src="*.gif"> in HTML for the score only (paths are relative, not listable as URLs)
+    const htmlGifPattern = /src\s*=\s*["']([^"']*\.gif)["']/gi
+    const htmlMatches = html.match(htmlGifPattern)
+    const htmlGifCount = htmlMatches ? htmlMatches.length : 0
+
+    const gifCount = gifRecords.length + htmlGifCount
+
+    return {
+      score: gifCount === 0 ? 1 : 0,
+      displayValue:
+        gifCount === 0
+          ? str_(UIStrings.displayValuePass)
+          : str_(UIStrings.displayValueFail, { count: gifCount }),
+      numericValue: gifCount,
+      numericUnit: 'unitless' as
+        | 'unitless'
+        | 'byte'
+        | 'millisecond'
+        | 'element',
+      details: {
+        type: 'table' as const,
+        headings: [
+          {
+            key: 'url',
+            label: str_(UIStrings.colLabelUrl),
+            valueType: 'url' as const,
+          },
+        ],
+        items: gifRecords.map(url => ({ url })),
+      } as LH.Audit.Details.Table,
+    }
+  }
+}
+
+export default BPRwebNoGif
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-gif.ts
+git commit -m "feat(bp): add GIF URL table to rweb-no-gif"
+```
+
+---
+
+## Task 12: Ajouter table à rweb-no-redirects
+
+**Files:**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-redirects.ts`
+
+- [ ] **Step 1: Ajouter `colLabelUrl` + `colLabelStatus` dans UIStrings et la table dans le retour**
+
+Ajouter dans `UIStrings` :
+
+```typescript
+colLabelUrl: 'URL',
+colLabelStatus: 'HTTP Status',
+```
+
+Remplacer le bloc `return` final par :
+
+```typescript
+return {
+  score: redirects.length <= MAX_REDIRECTS ? 1 : 0,
+  displayValue: str_(UIStrings.displayValue, { count: redirects.length }),
+  numericValue: redirects.length,
+  numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+  details: {
+    type: 'table' as const,
+    headings: [
+      {
+        key: 'url',
+        label: str_(UIStrings.colLabelUrl),
+        valueType: 'url' as const,
+      },
+      {
+        key: 'statusCode',
+        label: str_(UIStrings.colLabelStatus),
+        valueType: 'text' as const,
+      },
+    ],
+    items: redirects.map(r => ({
+      url: r.url,
+      statusCode: String(r.statusCode),
+    })),
+  } as LH.Audit.Details.Table,
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-redirects.ts
+git commit -m "feat(bp): add redirect URL table to rweb-no-redirects"
+```
+
+---
+
+## Task 13: Ajouter table à rweb-no-cookie-on-static
+
+**Files:**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-cookie-on-static.ts`
+
+- [ ] **Step 1: Ajouter `colLabelUrl` dans UIStrings et la table dans le retour**
+
+Ajouter dans `UIStrings` :
+
+```typescript
+colLabelUrl: 'Resource URL',
+```
+
+Remplacer le bloc `return` final par :
+
+```typescript
+return {
+  score: count === 0 ? 1 : 0,
+  displayValue:
+    count === 0
+      ? str_(UIStrings.displayValuePass)
+      : str_(UIStrings.displayValueFail, { count }),
+  numericValue: count,
+  numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+  details: {
+    type: 'table' as const,
+    headings: [
+      {
+        key: 'url',
+        label: str_(UIStrings.colLabelUrl),
+        valueType: 'url' as const,
+      },
+    ],
+    items: staticWithCookie.map(r => ({ url: r.url })),
+  } as LH.Audit.Details.Table,
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-cookie-on-static.ts
+git commit -m "feat(bp): add resource URL table to rweb-no-cookie-on-static"
+```
+
+---
+
+## Task 14: Ajouter table à rweb-no-social-sdk
+
+**Files:**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-social-sdk.ts`
+
+- [ ] **Step 1: Ajouter `colLabelUrl` dans UIStrings et la table dans le retour**
+
+Ajouter dans `UIStrings` :
+
+```typescript
+colLabelUrl: 'SDK URL',
+```
+
+Remplacer le bloc `return` final par :
+
+```typescript
+return {
+  score: sdkRequests.length === 0 ? 1 : 0,
+  displayValue: str_(UIStrings.displayValue, { count: sdkRequests.length }),
+  numericValue: sdkRequests.length,
+  numericUnit: 'unitless' as 'unitless' | 'byte' | 'millisecond' | 'element',
+  details: {
+    type: 'table' as const,
+    headings: [
+      {
+        key: 'url',
+        label: str_(UIStrings.colLabelUrl),
+        valueType: 'url' as const,
+      },
+    ],
+    items: sdkRequests.map(r => ({ url: r.url })),
+  } as LH.Audit.Details.Table,
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-social-sdk.ts
+git commit -m "feat(bp): add SDK URL table to rweb-no-social-sdk"
+```
+
+---
+
+## Task 15: Ajouter table à rweb-no-carousel
+
+**Files:**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-carousel.ts`
+
+- [ ] **Step 1: Collecter les URLs détectées + ajouter la table**
+
+Le fichier actuel compte les occurrences mais ne les conserve pas. Il faut stocker les URLs correspondantes.
+
+Remplacer la logique d'audit (le corps de la méthode `audit`) par :
+
+```typescript
+static async audit(artifacts: LH.Artifacts, context: LH.Audit.Context) {
+  const networkRecords = await NetworkRecords.request(
+    artifacts.DevtoolsLog,
+    context,
+  )
+
+  const carouselUrls: string[] = []
+
+  for (const record of networkRecords) {
+    if (NetworkRequest.isNonNetworkRequest(record)) continue
+    if (record.resourceType !== 'Script') continue
+
+    const urlLower = record.url.toLowerCase()
+    for (const lib of CAROUSEL_LIBS) {
+      if (urlLower.includes(lib)) {
+        carouselUrls.push(record.url)
+        break
+      }
+    }
+  }
+
+  return {
+    score: carouselUrls.length === 0 ? 1 : 0,
+    displayValue:
+      carouselUrls.length === 0
+        ? str_(UIStrings.displayValuePass)
+        : str_(UIStrings.displayValueFail, { count: carouselUrls.length }),
+    numericValue: carouselUrls.length,
+    numericUnit: 'unitless' as
+      | 'unitless'
+      | 'byte'
+      | 'millisecond'
+      | 'element',
+    details: {
+      type: 'table' as const,
+      headings: [
+        {
+          key: 'url',
+          label: str_(UIStrings.colLabelUrl),
+          valueType: 'url' as const,
+        },
+      ],
+      items: carouselUrls.map(url => ({ url })),
+    } as LH.Audit.Details.Table,
+  }
+}
+```
+
+Ajouter dans `UIStrings` :
+
+```typescript
+colLabelUrl: 'Carousel library URL',
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-carousel.ts
+git commit -m "feat(bp): add carousel URL table to rweb-no-carousel"
+```
+
+---
+
+## Task 16: Vérifications finales et changeset
+
+**Files:**
+
+- Create: `.changeset/*.md`
+
+- [ ] **Step 1: Typecheck strict complet**
+
+```bash
+pnpm typecheck:strict
+```
+
+Expected: exit 0, aucune erreur TypeScript. Si des erreurs apparaissent, corriger avant de continuer.
+
+- [ ] **Step 2: Lint**
+
+```bash
+pnpm lint
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Build**
+
+```bash
+pnpm build
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Créer le changeset**
+
+```bash
+pnpm changeset
+```
+
+- Choisir `patch` pour `lighthouse-plugin-ecoindex-core`
+- Message : `feat(bp): add details tables to 12 BP audits — now exposing domains, URLs, CSS selectors and code snippets alongside the score`
+
+- [ ] **Step 5: Commit final**
+
+```bash
+git add .changeset/
+git commit -m "chore: add changeset for audit details tables"
+```

--- a/.superpowers/specs/2026-05-09-missing-bp-audits-design.md
+++ b/.superpowers/specs/2026-05-09-missing-bp-audits-design.md
@@ -1,0 +1,249 @@
+# Design — 18 audits BP manquants (sprint unique)
+
+Date: 2026-05-09  
+Branche cible: `feat/rweb-bp-audits`  
+Approche retenue: **Sprint unique** — 1 PR pour les 18 audits + tests + doc.
+
+---
+
+## Contexte
+
+Le plugin implémente déjà 18 audits RWEB/BP. Il manque 18 audits supplémentaires listés dans `docs/bonnes-pratiques/01-bp-greenit.md`. GreenIT-Analysis (extension navigateur) prouve que chacun est automatisable.
+
+Architecture existante (à reproduire) :
+- Fichier audit: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-{slug}.ts`
+- Artifacts disponibles: `DevtoolsLog` (via `NetworkRecords.request()`), `MainDocumentContent`, `ConsoleMessages`, `ImageElements`
+- Helpers centraux (god nodes graphify): `createValueResult()`, `createErrorResult()`, `getLoadingExperience()`
+- Enregistrement: `libs/ecoindex-lh-plugin-ts/src/plugin.ts` (audits[] + auditRefs[])
+- URLs RWEB: `libs/ecoindex-lh-plugin-ts/src/audits/bp/refs-urls.ts` (générées par `pnpm refs:update`)
+
+---
+
+## Groupe A — Headers réseau (4 audits)
+
+### RWEB_0075 — Cache-Control
+- **Fichier**: `rweb-cache-control.ts` · **ID**: `rweb-cache-control`
+- **Artifact**: `DevtoolsLog`
+- **Logique**: Compter les ressources HTML/CSS/JS/fonts sans header `cache-control` dans la réponse
+- **Score**: 1 si 0 violation, 0 sinon
+- **bp-violations.html**: aucune modification nécessaire (le serveur Express local n'envoie pas `cache-control`)
+- **expected-results.json**: `"rweb-cache-control": 0`
+
+### RWEB_0076 — Compression HTTP
+- **Fichier**: `rweb-http-compression.ts` · **ID**: `rweb-http-compression`
+- **Artifact**: `DevtoolsLog`
+- **Logique**: Compter les ressources texte (HTML/CSS/JS) sans header `content-encoding` (`gzip|br|deflate|zstd`)
+- **Score**: `compressed / total` (ratio, seuil 0.95 pour score=1)
+- **bp-violations.html**: aucune modification (serveur local ne compresse pas)
+- **expected-results.json**: `"rweb-http-compression": 0`
+
+### RWEB_0083 — HTTP/2
+- **Fichier**: `rweb-uses-http2.ts` · **ID**: `rweb-uses-http2`
+- **Artifact**: `DevtoolsLog`
+- **Logique**: Compter les ressources dont `protocol !== 'h2'`
+- **Score**: 1 si toutes en HTTP/2, 0 sinon
+- **bp-violations.html**: aucune modification (localhost = HTTP/1.1)
+- **expected-results.json**: `"rweb-uses-http2": 0`
+
+### RWEB_0062 — Taille des cookies (≤ 512 octets)
+- **Fichier**: `rweb-cookie-size.ts` · **ID**: `rweb-cookie-size`
+- **Artifact**: `DevtoolsLog`
+- **Logique**: Trouver les headers `Cookie` de requête dont la valeur dépasse 512 bytes
+- **Score**: 1 si 0 violation, 0 sinon
+- **bp-violations.html + server.js**: modifier la route `/bp-violations` dans `server.js` pour envoyer `res.cookie('bigcookie', 'x'.repeat(520))` — les sous-requêtes (placeholder.gif) incluront alors le cookie volumineux
+- **expected-results.json**: `"rweb-cookie-size": 0`
+
+---
+
+## Groupe B — Statut et comptage réseau (3 audits)
+
+### HttpError — Erreurs HTTP (4xx/5xx)
+- **Fichier**: `rweb-no-http-errors.ts` · **ID**: `rweb-no-http-errors`
+- **Artifact**: `DevtoolsLog`
+- **Logique**: Compter les réponses avec `status >= 400`
+- **Score**: 1 si 0 erreur, 0 sinon. Afficher tableau des URLs en erreur.
+- **bp-violations.html**: ajouter `<img src="/this-image-does-not-exist-404.png" alt="404 test">`
+- **expected-results.json**: `"rweb-no-http-errors": 0`
+
+### RWEB_0035 — Limiter les feuilles CSS (≤ 7)
+- **Fichier**: `rweb-limit-css-files.ts` · **ID**: `rweb-limit-css-files`
+- **Artifact**: `DevtoolsLog`
+- **Logique**: Compter les réponses `content-type: text/css`
+  - Score 1 si ≤ 7 (grade A)
+  - Score 0.5 si 8–10 (grade B)
+  - Score 0 si > 10 (grade C)
+- **bp-violations.html**: ajouter 8 balises `<link rel="stylesheet" href="/styles/styleN.css">`. Créer 8 fichiers CSS vides dans `test/test-pages/styles/`.
+- **expected-results.json**: `"rweb-limit-css-files": 0.5` (8 CSS = grade B)
+
+### RWEB_0078 — Combiner CSS et JS
+- **Fichier**: `rweb-combine-assets.ts` · **ID**: `rweb-combine-assets`
+- **Artifact**: `DevtoolsLog`
+- **Logique**: Compter les fichiers CSS externes + JS externes. Seuil: ≤ 10 chacun.
+  - Score 1 si CSS ≤ 10 ET JS ≤ 10
+  - Score 0.5 si l'un dépasse 10
+  - Score 0 si l'un dépasse 15
+- **bp-violations.html**: les 8 CSS déjà ajoutés pour RWEB_0035 + ajouter 3 `<script src="/js/libN.js">`. Créer ces fichiers dans `test/test-pages/js/`.
+- **expected-results.json**: `"rweb-combine-assets": 0.5` (8 CSS > seuil B)
+
+---
+
+## Groupe C — DOM et JS (5 audits)
+
+### RWEB_0051 — Chargement paresseux des images
+- **Fichier**: `rweb-lazy-loading.ts` · **ID**: `rweb-lazy-loading`
+- **Artifact**: `MainDocumentContent`
+- **Logique**: Compter `<img>` sans attribut `loading="lazy"` (regex sur le HTML brut)
+- **Score**: 1 si 0 image sans lazy, 0 sinon
+- **bp-violations.html**: déjà présent (`<img src="placeholder.gif">` sans lazy)
+- **expected-results.json**: `"rweb-lazy-loading": 0`
+
+### RWEB_0044 — Pas de manipulation DOM interdite
+- **Fichier**: `rweb-no-document-write.ts` · **ID**: `rweb-no-document-write`
+- **Artifact**: `MainDocumentContent`
+- **Logique**: Chercher l'usage de `document.write` dans les scripts inline du HTML
+- **Score**: 1 si 0 occurrence, 0 sinon
+- **bp-violations.html**: ajouter un script inline utilisant `document.write` dans le body
+- **expected-results.json**: `"rweb-no-document-write": 0`
+
+### ImageDownloadedNotDisplayed — Images chargées mais non affichées
+- **Fichier**: `rweb-no-hidden-images.ts` · **ID**: `rweb-no-hidden-images`
+- **Artifact**: `ImageElements` (Lighthouse artifact natif)
+- **Logique**: Filtrer les `ImageElements` dont `naturalDimensions.width > 0` ET (`clientRect.width === 0` OU `clientRect.height === 0`)
+- **Score**: 1 si 0 image cachée, 0 sinon
+- **bp-violations.html**: ajouter `<img src="placeholder.gif" alt="hidden" style="display:none" width="100" height="100">`
+- **expected-results.json**: `"rweb-no-hidden-images": 0`
+
+### RWEB_0043 — Valider le JS (pas d'erreurs console)
+- **Fichier**: `rweb-no-js-errors.ts` · **ID**: `rweb-no-js-errors`
+- **Artifact**: `ConsoleMessages`
+- **Logique**: Filtrer les messages avec `level === 'error'` ou `type === 'error'`
+- **Score**: 1 si 0 erreur, 0 sinon. Afficher tableau des messages.
+- **bp-violations.html**: ajouter un script inline appelant une fonction non définie (génère une ReferenceError)
+- **expected-results.json**: `"rweb-no-js-errors": 0`
+
+### Plugins — Pas de plugins navigateur
+- **Fichier**: `rweb-no-plugins.ts` · **ID**: `rweb-no-plugins`
+- **Artifact**: `MainDocumentContent`
+- **Logique**: Détecter `<object>` ou `<embed>` avec MIME types plugin:
+  - `application/x-shockwave-flash`
+  - `application/x-silverlight`, `application/x-silverlight-2`
+  - `application/java-applet`, `application/x-java-applet`
+- **Score**: 1 si 0 trouvé, 0 sinon
+- **bp-violations.html**: ajouter `<object type="application/x-shockwave-flash" data="movie.swf" width="1" height="1"></object>`
+- **expected-results.json**: `"rweb-no-plugins": 0`
+
+---
+
+## Groupe D — Analyse de contenu (2 audits)
+
+### RWEB_0077 — Minification CSS/JS
+- **Fichier**: `rweb-minification.ts` · **ID**: `rweb-minification`
+- **Artifact**: `MainDocumentContent`
+- **Logique** (heuristique, même approche que GreenIT-Analysis `MinifiedCssJs.js`):
+  - Pour chaque bloc `<style>` et `<script>` inline: calculer `charCount / lineCount`
+  - Si ratio < 80 chars/ligne ET contenu > 200 chars → non minifié
+- **Score**: 1 si tous les blocs inline paraissent minifiés, 0 sinon
+- **Note**: les fichiers externes nécessitent un gatherer custom pour accéder au contenu — hors scope v1. L'audit couvre uniquement l'inline.
+- **bp-violations.html**: les 2 `<style>` et 3 `<script>` inline multi-lignes déjà présents déclenchent la violation
+- **expected-results.json**: `"rweb-minification": 0`
+
+### RWEB_0100 — Optimiser les SVG
+- **Fichier**: `rweb-optimize-svg.ts` · **ID**: `rweb-optimize-svg`
+- **Artifact**: `DevtoolsLog`
+- **Logique** (heuristique):
+  - Trouver les requêtes `content-type: image/svg+xml` ou URL `.svg`
+  - Si `resourceSize > 2048` bytes → probablement non optimisé (métadonnées, commentaires)
+- **Score**: 1 si 0 SVG > 2KB, 0 sinon
+- **bp-violations.html**: ajouter `<img src="/images/unoptimized.svg">`. Créer un SVG non optimisé (> 2KB avec commentaires/métadonnées) dans `test/test-pages/images/`.
+- **expected-results.json**: `"rweb-optimize-svg": 0`
+
+---
+
+## Groupe E — Heuristiques (4 audits)
+
+### RWEB_0037 — Préférer CSS aux images (icônes)
+- **Fichier**: `rweb-prefer-css.ts` · **ID**: `rweb-prefer-css`
+- **Artifact**: `MainDocumentContent`
+- **Logique**: Détecter `<img>` directement enfant de `<button>`, `<a>`, ou `<li>` dans un `<nav>` → usage iconique probable (regex multiline)
+- **Score**: 1 si 0 trouvé, 0 sinon (audit informatif)
+- **bp-violations.html**: ajouter `<button><img src="/images/icon.png" alt="icon"></button>`
+- **expected-results.json**: `"rweb-prefer-css": 0`
+
+### RWEB_0038 — Éviter les images matricielles pour l'interface
+- **Fichier**: `rweb-no-bitmap-ui.ts` · **ID**: `rweb-no-bitmap-ui`
+- **Artifact**: `MainDocumentContent`
+- **Logique**: Détecter images bitmap (`.png|.jpg|.jpeg|.bmp|.webp`) dans `<header>`, `<nav>`, `<footer>`, `<button>`
+- **Score**: 1 si 0 trouvé, 0 sinon (audit informatif)
+- **bp-violations.html**: ajouter `<header><img src="/images/logo.png" alt="logo"></header>`
+- **expected-results.json**: `"rweb-no-bitmap-ui": 0`
+
+### RWEB_0046 — Ne charger que le code nécessaire
+- **Fichier**: `rweb-no-unused-code.ts` · **ID**: `rweb-no-unused-code`
+- **Artifact**: `MainDocumentContent` + `DevtoolsLog`
+- **Logique**: Détecter `<script src="...">` externes sans attributs `async` ou `defer` → scripts bloquants = code potentiellement inutile au chemin critique
+- **Score**: 1 si 0 script bloquant externe, 0 sinon (audit informatif)
+- **bp-violations.html**: ajouter `<script src="/js/lib1.js"></script>` (sans async/defer)
+- **expected-results.json**: `"rweb-no-unused-code": 0`
+
+### RWEB_0036 — Découper les CSS
+- **Fichier**: `rweb-css-splitting.ts` · **ID**: `rweb-css-splitting`
+- **Artifact**: `MainDocumentContent` + `DevtoolsLog`
+- **Logique**: Si des fichiers CSS > 10KB sont chargés sans attribut `media` spécifique (= pas de découpage par contexte)
+  - Vérifier `<link rel="stylesheet">` sans `media` ou avec `media="all"` ET taille > 10KB
+- **Score**: 1 si tous les CSS ont un `media` ciblé OU sont < 10KB, 0 sinon (audit informatif)
+- **bp-violations.html**: 2 des 8 CSS déjà ajoutés pour RWEB_0035 seront > 10KB (remplis de padding CSS)
+- **expected-results.json**: `"rweb-css-splitting": 0`
+
+---
+
+## Modifications fichiers transverses
+
+### `refs-urls.ts` — 15 nouveaux IDs via `pnpm refs:update`
+IDs manquants: `RWEB_0035`, `RWEB_0036`, `RWEB_0037`, `RWEB_0038`, `RWEB_0043`, `RWEB_0044`, `RWEB_0046`, `RWEB_0051`, `RWEB_0062`, `RWEB_0075`, `RWEB_0076`, `RWEB_0077`, `RWEB_0078`, `RWEB_0083`, `RWEB_0100`
+
+Note: `rweb-no-plugins` et `rweb-no-http-errors` n'ont pas d'ID RWEB canonique — description statique dans le fichier audit.
+
+### `plugin.ts` — 18 entrées à ajouter
+Dans `audits[]`: 18 `{ path: '${__dirname}/audits/bp/rweb-{slug}.js' }`  
+Dans `auditRefs[]`: 18 `{ id: 'rweb-{slug}', weight: 0, group: 'ecoindex-best-practices' }`
+
+### `docs/bonnes-pratiques/01-bp-greenit.md`
+Cocher les 18 items actuellement décochés une fois implémentés.
+
+---
+
+## Stratégie de tests (LHCI — pattern existant)
+
+1. **`test/test-pages/bp-violations.html`**: ajouter les éléments HTML décrits par audit ci-dessus
+2. **`test/test-pages/server.js`**: ajouter `res.cookie('bigcookie', 'x'.repeat(520))` sur la route `/bp-violations`
+3. **`test/test-pages/styles/`**: créer `style1.css` à `style8.css` (6 vides + 2 > 10KB avec padding CSS)
+4. **`test/test-pages/js/`**: créer `lib1.js`, `lib2.js`, `lib3.js` (vides)
+5. **`test/test-pages/images/`**: créer `unoptimized.svg` (> 2KB), `icon.png`, `logo.png` (1x1px)
+6. **`test/test-pages/expected-results.json`**: ajouter 18 entrées dans `bp-violations.expectedBPAudits`
+
+---
+
+## Ordre d'implémentation
+
+1. `pnpm refs:update` → générer les 15 nouvelles URLs
+2. Groupe A (4 audits)
+3. Groupe B (3 audits)
+4. Groupe C (5 audits)
+5. Groupe D (2 audits)
+6. Groupe E (4 audits)
+7. Transversal: `plugin.ts`, `bp-violations.html`, assets de test, `expected-results.json`, `server.js`
+8. `pnpm test` pour validation LHCI
+9. Mise à jour `docs/bonnes-pratiques/01-bp-greenit.md`
+10. Changeset
+
+---
+
+## Risques et limites
+
+| Audit | Limite |
+|-------|--------|
+| RWEB_0077 | Couvre uniquement l'inline — fichiers externes nécessiteraient un gatherer custom |
+| RWEB_0100 | Heuristique taille (pas d'analyse du contenu SVG réel) |
+| RWEB_0036–0038–0046 | Heuristiques — faux positifs possibles sur pages complexes |
+| RWEB_0062 | Nécessite modification de server.js pour injecter un cookie sur bp-violations |
+| RWEB_0043 | L'erreur JS doit se produire au runtime Lighthouse (headless Chrome) |

--- a/.superpowers/specs/2026-05-25-audit-details-tables-design.md
+++ b/.superpowers/specs/2026-05-25-audit-details-tables-design.md
@@ -1,0 +1,237 @@
+# Design — Ajout de tables `details` dans les audits BP
+
+Date: 2026-05-25
+Branche cible: `feat/audit-details-tables`
+
+---
+
+## Contexte
+
+Plusieurs audits BP se contentent d'un score et d'un `displayValue` numérique. Le rapport Lighthouse n'indique pas _quels_ éléments sont en cause — l'utilisateur sait qu'il y a 3 domaines trop nombreux, mais pas lesquels. L'objectif est d'ajouter une table `details` dans chaque audit concerné, sur le modèle de `rweb-limit-css-files`.
+
+12 audits sont concernés en deux groupes :
+
+- **Groupe 1 (4 audits)** : données à extraire via une extension du `BPGatherer`
+- **Groupe 2 (8 audits)** : données déjà disponibles dans l'audit, table triviale à ajouter
+
+---
+
+## Section 1 — Extension du BPGatherer
+
+**Fichiers touchés :**
+
+- `libs/ecoindex-lh-plugin-ts/src/gatherers/bp-gatherer.ts`
+- `libs/ecoindex-lh-plugin-ts/src/types/index.d.ts`
+
+La fonction `collectBPData()` (exécutée dans le contexte navigateur) est étendue pour retourner des tableaux d'objets en plus des compteurs existants.
+
+### Nouveaux champs retournés
+
+```ts
+inlineScriptDetails: {
+  snippet: string
+}
+;[]
+// premiers 120 chars de textContent de chaque <script> inline non-JSON-LD
+
+inlineStyleDetails: {
+  snippet: string
+}
+;[]
+// premiers 120 chars de textContent de chaque <style>
+
+animatedElementDetails: {
+  selector: string
+  property: string
+}
+;[]
+// selector = "tagName#id.class1.class2"
+// property = "animation: <animationName>" ou "transition: <transitionProperty>"
+
+autoplayDetails: {
+  selector: string
+  src: string
+}
+;[]
+// selector = "tagName#id.class1.class2"
+// src = valeur de l'attribut src, ou "" si absent
+
+canvasDetails: {
+  selector: string
+}
+;[]
+// selector = "tagName#id.class1.class2"
+```
+
+Les compteurs entiers existants (`inlineScripts`, `inlineStyles`, `animatedElements`, etc.) sont supprimés — les audits utilisent `.length` du nouveau tableau. Cela simplifie le gatherer sans casser l'interface observable.
+
+### Mise à jour de `BPGathererResult` (types/index.d.ts)
+
+```ts
+export interface BPGathererResult {
+  autoplaying: number // supprimé → remplacé par autoplayDetails.length dans l'audit
+  serviceWorkerActive: boolean // inchangé
+  canvasCount: number // supprimé → remplacé par canvasDetails.length
+  inlineScripts: number // supprimé → remplacé par inlineScriptDetails.length
+  inlineStyles: number // supprimé → remplacé par inlineStyleDetails.length
+  animatedElements: number // supprimé → remplacé par animatedElementDetails.length
+  inlineScriptDetails: { snippet: string }[]
+  inlineStyleDetails: { snippet: string }[]
+  animatedElementDetails: { selector: string; property: string }[]
+  autoplayDetails: { selector: string; src: string }[]
+  canvasDetails: { selector: string }[]
+}
+```
+
+---
+
+## Section 2 — Audits Groupe 1 (données BPGatherer)
+
+Les 4 audits sont mis à jour pour utiliser les nouveaux tableaux.
+
+> **Règle table Groupe 1 :** la table n'est incluse dans le résultat que si score = 0 (liste non vide). Quand score = 1, `details` est omis. Raison : les tableaux proviennent du navigateur via `executionContext.evaluate` — retourner une liste vide a un coût inutile.
+
+### `rweb-no-inline-assets`
+
+- Count : `inlineScriptDetails.length + inlineStyleDetails.length`
+- Table (si score = 0) :
+
+| Colonne | valueType | Source                    |
+| ------- | --------- | ------------------------- |
+| Type    | `text`    | `"script"` ou `"style"`   |
+| Extrait | `text`    | `snippet` (120 chars max) |
+
+Items : `[...inlineScriptDetails.map(d => ({ type: 'script', snippet: d.snippet })), ...inlineStyleDetails.map(d => ({ type: 'style', snippet: d.snippet }))]`
+
+### `rweb-no-animations`
+
+- Count : `animatedElementDetails.length`
+- Table (si score = 0) :
+
+| Colonne   | valueType | Source     |
+| --------- | --------- | ---------- |
+| Élément   | `text`    | `selector` |
+| Propriété | `text`    | `property` |
+
+### `rweb-no-autoplay`
+
+- Count : `autoplayDetails.length`
+- Table (si score = 0) :
+
+| Colonne | valueType | Source                   |
+| ------- | --------- | ------------------------ |
+| Élément | `text`    | `selector`               |
+| Source  | `url`     | `src` (ou `"—"` si vide) |
+
+### `rweb-no-canvas`
+
+- Count : `canvasDetails.length`
+- Table (si score = 0) :
+
+| Colonne | valueType | Source     |
+| ------- | --------- | ---------- |
+| Élément | `text`    | `selector` |
+
+**Règle commune :** la table n'est incluse dans le résultat que si le score est 0 (liste non vide). Quand score = 1, `details` est omis.
+
+---
+
+## Section 3 — Audits Groupe 2 (données déjà disponibles)
+
+Ajout d'un bloc `details` sans modifier la logique métier. La table est toujours présente (même vide quand score = 1), conformément au pattern de `rweb-limit-css-files`.
+
+### `rweb-limit-domains`
+
+| Colonne | valueType | Source                                   |
+| ------- | --------- | ---------------------------------------- |
+| Domaine | `text`    | `[...domains].map(d => ({ domain: d }))` |
+
+### `rweb-limit-fonts`
+
+| Colonne | valueType | Source                                        |
+| ------- | --------- | --------------------------------------------- |
+| Domaine | `text`    | `[...fontFamilies].map(d => ({ domain: d }))` |
+
+### `rweb-limit-analytics`
+
+| Colonne | valueType | Source                                          |
+| ------- | --------- | ----------------------------------------------- |
+| Domaine | `text`    | `[...matchedDomains].map(d => ({ domain: d }))` |
+
+### `rweb-no-gif`
+
+Seules les URLs issues des network records sont listées (les matches HTML regex donnent des chemins relatifs non exploitables comme URL Lighthouse).
+
+| Colonne | valueType | Source                                  |
+| ------- | --------- | --------------------------------------- |
+| URL     | `url`     | `gifRecords.map(r => ({ url: r.url }))` |
+
+La détection HTML reste pour le score global (mais sans entrée dans la table).
+
+### `rweb-no-redirects`
+
+| Colonne   | valueType | Source                                                           |
+| --------- | --------- | ---------------------------------------------------------------- |
+| URL       | `url`     | `redirects.map(r => ({ url: r.url, statusCode: r.statusCode }))` |
+| Code HTTP | `text`    | idem                                                             |
+
+### `rweb-no-cookie-on-static`
+
+| Colonne | valueType | Source                                        |
+| ------- | --------- | --------------------------------------------- |
+| URL     | `url`     | `staticWithCookie.map(r => ({ url: r.url }))` |
+
+### `rweb-no-social-sdk`
+
+| Colonne | valueType | Source                                   |
+| ------- | --------- | ---------------------------------------- |
+| URL     | `url`     | `sdkRequests.map(r => ({ url: r.url }))` |
+
+### `rweb-no-carousel`
+
+Les URLs des librairies carousel sont issues des network records (même logique que `rweb-limit-analytics`).
+
+| Colonne | valueType | Source                                     |
+| ------- | --------- | ------------------------------------------ |
+| URL     | `url`     | URLs réseau matchant les patterns carousel |
+
+---
+
+## Fichiers modifiés
+
+| Fichier                                 | Type de changement                                                |
+| --------------------------------------- | ----------------------------------------------------------------- |
+| `gatherers/bp-gatherer.ts`              | Extension `collectBPData()` + suppression des compteurs remplacés |
+| `types/index.d.ts`                      | Mise à jour `BPGathererResult`                                    |
+| `audits/bp/rweb-no-inline-assets.ts`    | Groupe 1 — ajout table                                            |
+| `audits/bp/rweb-no-animations.ts`       | Groupe 1 — ajout table                                            |
+| `audits/bp/rweb-no-autoplay.ts`         | Groupe 1 — ajout table                                            |
+| `audits/bp/rweb-no-canvas.ts`           | Groupe 1 — ajout table                                            |
+| `audits/bp/rweb-limit-domains.ts`       | Groupe 2 — ajout table                                            |
+| `audits/bp/rweb-limit-fonts.ts`         | Groupe 2 — ajout table                                            |
+| `audits/bp/rweb-limit-analytics.ts`     | Groupe 2 — ajout table                                            |
+| `audits/bp/rweb-no-gif.ts`              | Groupe 2 — ajout table                                            |
+| `audits/bp/rweb-no-redirects.ts`        | Groupe 2 — ajout table                                            |
+| `audits/bp/rweb-no-cookie-on-static.ts` | Groupe 2 — ajout table                                            |
+| `audits/bp/rweb-no-social-sdk.ts`       | Groupe 2 — ajout table                                            |
+| `audits/bp/rweb-no-carousel.ts`         | Groupe 2 — ajout table                                            |
+
+---
+
+## Ordre d'implémentation
+
+1. `gatherers/bp-gatherer.ts` + `types/index.d.ts` (base pour le groupe 1)
+2. Groupe 1 : `rweb-no-inline-assets`, `rweb-no-animations`, `rweb-no-autoplay`, `rweb-no-canvas`
+3. Groupe 2 : les 8 audits (indépendants, ordre libre)
+4. `pnpm typecheck:strict` + `pnpm lint`
+5. Changeset
+
+---
+
+## Risques et limites
+
+| Point                    | Détail                                                                                                                                           |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `animatedElementDetails` | Peut être très long sur des pages avec beaucoup d'éléments animés — **troncature à 50 entrées max** appliquée dans le gatherer (`.slice(0, 50)`) |
+| `rweb-no-gif`            | Matches HTML exclus de la table (chemins relatifs) — score peut être > 0 avec 0 ligne dans la table si tous les GIFs sont inline                 |
+| Rétrocompatibilité       | La suppression des compteurs entiers dans `BPGathererResult` est un breaking change pour tout consommateur externe du type                       |

--- a/docs/guides/1-lighthouse-ecoindex-cli.md
+++ b/docs/guides/1-lighthouse-ecoindex-cli.md
@@ -107,6 +107,7 @@ Sert à lancer la collecte des audits Lighthouse et EcoIndex suivant les options
 - `-a, --audit-category` : Audit à exécuter, supporte plusieurs valeurs. Available categories: "accessibility", "best-practices", "performance", "seo" and "lighthouse-plugin-ecoindex-core".
 - `--user-agent` : User-Agent à utiliser pour les requêtes.
 - `--auth` : Moyen de s'authentifier pendant les mesures (`--auth.url`, `--auth.user.target`, `--auth.user.value`, etc. voir le tableau plus bas).
+- `--lang` : Langue des rapports générés. Valeurs possibles : `"en"` (anglais), `"fr"` (français). Par défaut : `"en"`.
 - `--help` : Affiche l'aide.
 
 #### Exemples

--- a/libs/ecoindex-lh-courses/src/utils/default-puppeteer.ts
+++ b/libs/ecoindex-lh-courses/src/utils/default-puppeteer.ts
@@ -3,17 +3,14 @@ import type * as LH from 'lighthouse/types/lh.js'
 import { Auth } from '../types/index.js'
 import { exit } from 'process'
 import logSymbols from 'log-symbols'
-import puppeteer from 'puppeteer'
+import type { Browser, CDPSession, Page } from 'puppeteer'
 
 /**
  * Init Ecoindex flow. Wait 3s, then navigate to bottom of page.
- * @param {puppeteer.Page} page
- * @param {puppeteer.CDPSession} session
+ * @param {Page} page
+ * @param {CDPSession} session
  */
-async function startEcoindexPageMesure(
-  page: puppeteer.Page,
-  session: puppeteer.CDPSession,
-) {
+async function startEcoindexPageMesure(page: Page, session: CDPSession) {
   page.setViewport({
     width: 1920,
     height: 1080,
@@ -69,10 +66,10 @@ async function endEcoindexPageMesure(
  * @param {object} authenticate
  */
 async function authenticateEcoindexPageMesure(
-  page: puppeteer.Page,
+  page: Page,
   authenticate: Auth,
-  _browser: puppeteer.Browser,
-  session: puppeteer.CDPSession,
+  _browser: Browser,
+  session: CDPSession,
   flow: LH.UserFlow,
 ) {
   await page.setViewport({
@@ -83,7 +80,7 @@ async function authenticateEcoindexPageMesure(
     await page.type(authenticate.user.target, authenticate.user.value)
     const searchValue = await page.$eval(
       authenticate.user.target,
-      el => (el as HTMLInputElement).value,
+      (el: Element) => (el as HTMLInputElement).value,
     )
     console.log(
       `${logSymbols.info} (test) ${authenticate.user.target} setted with`,

--- a/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-analytics.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-analytics.ts
@@ -29,6 +29,7 @@ const UIStrings = {
   description:
     'Limit analytics tools to one per page. [See RWEB_0111](https://rweb.greenit.fr/es/fiches/RWEB_0111-limitar-las-herramientas-de-analisis-y-los-datos-recopilados)',
   displayValue: '{count} analytics tool(s) detected',
+  colLabelDomain: 'Analytics domain',
 }
 const str_ = createIcuMessageFn('audits/bp/rweb-limit-analytics.js', UIStrings)
 
@@ -70,6 +71,17 @@ class BPRwebLimitAnalytics extends Audit {
         | 'byte'
         | 'millisecond'
         | 'element',
+      details: {
+        type: 'table' as const,
+        headings: [
+          {
+            key: 'domain',
+            label: str_(UIStrings.colLabelDomain),
+            valueType: 'text' as const,
+          },
+        ],
+        items: [...matchedDomains].map(domain => ({ domain })),
+      } as LH.Audit.Details.Table,
     }
   }
 }

--- a/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-domains.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-domains.ts
@@ -18,6 +18,7 @@ const UIStrings = {
   description:
     'Reduce the number of unique domains serving page resources. [See RWEB_0082](https://rweb.greenit.fr/en/fiches/RWEB_0082-limit-the-number-of-domains-serving-resources)',
   displayValue: '{count} unique domain(s)',
+  colLabelDomain: 'Domain',
 }
 const str_ = createIcuMessageFn('audits/bp/rweb-limit-domains.js', UIStrings)
 
@@ -61,6 +62,17 @@ class BPRwebLimitDomains extends Audit {
         | 'byte'
         | 'millisecond'
         | 'element',
+      details: {
+        type: 'table' as const,
+        headings: [
+          {
+            key: 'domain',
+            label: str_(UIStrings.colLabelDomain),
+            valueType: 'text' as const,
+          },
+        ],
+        items: [...domains].map(domain => ({ domain })),
+      } as LH.Audit.Details.Table,
     }
   }
 }

--- a/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-fonts.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-limit-fonts.ts
@@ -19,6 +19,7 @@ const UIStrings = {
     'Reduce the number of external font families loaded. [See RWEB_0032](https://rweb.greenit.fr/en/fiches/RWEB_0032-prefer-standard-fonts)',
   displayValue:
     '{count, plural, one {# external font family} other {# external font families}}',
+  colLabelDomain: 'Font domain',
 }
 const str_ = createIcuMessageFn('audits/bp/rweb-limit-fonts.js', UIStrings)
 
@@ -73,6 +74,17 @@ class BPRwebLimitFonts extends Audit {
         | 'byte'
         | 'millisecond'
         | 'element',
+      details: {
+        type: 'table' as const,
+        headings: [
+          {
+            key: 'domain',
+            label: str_(UIStrings.colLabelDomain),
+            valueType: 'text' as const,
+          },
+        ],
+        items: [...fontFamilies].map(domain => ({ domain })),
+      } as LH.Audit.Details.Table,
     }
   }
 }

--- a/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-animations.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-animations.ts
@@ -16,6 +16,8 @@ const UIStrings = {
     'Avoid animations and transitions to reduce CPU and battery usage. [See RWEB_0009](https://rweb.greenit.fr/en/fiches/RWEB_0009-avoid-javascriptcss-animations)',
   displayValuePass: 'No animated elements',
   displayValueFail: '{count} animated element(s) found',
+  colLabelElement: 'Element',
+  colLabelProperty: 'Property',
 }
 const str_ = createIcuMessageFn('audits/bp/rweb-no-animations.js', UIStrings)
 
@@ -35,20 +37,42 @@ class BPRwebNoAnimations extends Audit {
   }
 
   static audit(artifacts: LH.Artifacts & BPArtifacts): LH.Audit.Product {
-    const { animatedElements } = artifacts.BPGatherer
+    const { animatedElementDetails } = artifacts.BPGatherer
+    const count = animatedElementDetails.length
 
     return {
-      score: animatedElements === 0 ? 1 : 0,
+      score: count === 0 ? 1 : 0,
       displayValue:
-        animatedElements === 0
+        count === 0
           ? str_(UIStrings.displayValuePass)
-          : str_(UIStrings.displayValueFail, { count: animatedElements }),
-      numericValue: animatedElements,
+          : str_(UIStrings.displayValueFail, { count }),
+      numericValue: count,
       numericUnit: 'unitless' as
         | 'unitless'
         | 'byte'
         | 'millisecond'
         | 'element',
+      ...(count > 0 && {
+        details: {
+          type: 'table' as const,
+          headings: [
+            {
+              key: 'selector',
+              label: str_(UIStrings.colLabelElement),
+              valueType: 'text' as const,
+            },
+            {
+              key: 'property',
+              label: str_(UIStrings.colLabelProperty),
+              valueType: 'text' as const,
+            },
+          ],
+          items: animatedElementDetails.map(d => ({
+            selector: d.selector,
+            property: d.property,
+          })),
+        } as LH.Audit.Details.Table,
+      }),
     }
   }
 }

--- a/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-autoplay.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-autoplay.ts
@@ -15,6 +15,8 @@ const UIStrings = {
   description:
     'Avoid autoplay on video and audio elements. [See RWEB_0106](https://rweb.greenit.fr/es/fiches/RWEB_0106-evitar-la-reproduccion-y-carga-automatica-de-videos-y-sonidos)',
   displayValue: '{count} autoplay element(s)',
+  colLabelElement: 'Element',
+  colLabelSrc: 'Source',
 }
 const str_ = createIcuMessageFn('audits/bp/rweb-no-autoplay.js', UIStrings)
 
@@ -34,17 +36,39 @@ class BPRwebNoAutoplay extends Audit {
   }
 
   static audit(artifacts: LH.Artifacts & BPArtifacts) {
-    const { autoplaying } = artifacts.BPGatherer
+    const { autoplayDetails } = artifacts.BPGatherer
+    const count = autoplayDetails.length
 
     return {
-      score: autoplaying === 0 ? 1 : 0,
-      displayValue: str_(UIStrings.displayValue, { count: autoplaying }),
-      numericValue: autoplaying,
+      score: count === 0 ? 1 : 0,
+      displayValue: str_(UIStrings.displayValue, { count }),
+      numericValue: count,
       numericUnit: 'unitless' as
         | 'unitless'
         | 'byte'
         | 'millisecond'
         | 'element',
+      ...(count > 0 && {
+        details: {
+          type: 'table' as const,
+          headings: [
+            {
+              key: 'selector',
+              label: str_(UIStrings.colLabelElement),
+              valueType: 'text' as const,
+            },
+            {
+              key: 'src',
+              label: str_(UIStrings.colLabelSrc),
+              valueType: 'text' as const,
+            },
+          ],
+          items: autoplayDetails.map(d => ({
+            selector: d.selector,
+            src: d.src || '—',
+          })),
+        } as LH.Audit.Details.Table,
+      }),
     }
   }
 }

--- a/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-canvas.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-canvas.ts
@@ -16,6 +16,7 @@ const UIStrings = {
     'Minimize the use of canvas elements. [See RWEB_0055](https://rweb.greenit.fr/en/fiches/RWEB_0055-limit-canvas-use)',
   displayValuePass: 'No canvas elements',
   displayValueFail: '{count} canvas element(s) found',
+  colLabelElement: 'Element',
 }
 const str_ = createIcuMessageFn('audits/bp/rweb-no-canvas.js', UIStrings)
 
@@ -35,20 +36,34 @@ class BPRwebNoCanvas extends Audit {
   }
 
   static audit(artifacts: LH.Artifacts & BPArtifacts) {
-    const { canvasCount } = artifacts.BPGatherer
+    const { canvasDetails } = artifacts.BPGatherer
+    const count = canvasDetails.length
 
     return {
-      score: canvasCount === 0 ? 1 : 0,
+      score: count === 0 ? 1 : 0,
       displayValue:
-        canvasCount === 0
+        count === 0
           ? str_(UIStrings.displayValuePass)
-          : str_(UIStrings.displayValueFail, { count: canvasCount }),
-      numericValue: canvasCount,
+          : str_(UIStrings.displayValueFail, { count }),
+      numericValue: count,
       numericUnit: 'unitless' as
         | 'unitless'
         | 'byte'
         | 'millisecond'
         | 'element',
+      ...(count > 0 && {
+        details: {
+          type: 'table' as const,
+          headings: [
+            {
+              key: 'selector',
+              label: str_(UIStrings.colLabelElement),
+              valueType: 'text' as const,
+            },
+          ],
+          items: canvasDetails.map(d => ({ selector: d.selector })),
+        } as LH.Audit.Details.Table,
+      }),
     }
   }
 }

--- a/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-carousel.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-carousel.ts
@@ -13,6 +13,7 @@ const UIStrings = {
   displayValuePass: 'No carousel libraries detected',
   displayValueFail:
     '{count, plural, one {# carousel library detected} other {# carousel libraries detected}}',
+  colLabelUrl: 'Carousel library URL',
 }
 const str_ = createIcuMessageFn('audits/bp/rweb-no-carousel.js', UIStrings)
 
@@ -33,9 +34,8 @@ class BPRwebNoCarousel extends Audit {
       context,
     )
 
-    let carouselCount = 0
+    const carouselUrls: string[] = []
 
-    // Check network records for carousel library scripts
     for (const record of networkRecords) {
       if (NetworkRequest.isNonNetworkRequest(record)) continue
       if (record.resourceType !== 'Script') continue
@@ -43,24 +43,35 @@ class BPRwebNoCarousel extends Audit {
       const urlLower = record.url.toLowerCase()
       for (const lib of CAROUSEL_LIBS) {
         if (urlLower.includes(lib)) {
-          carouselCount++
-          break // Count each URL only once
+          carouselUrls.push(record.url)
+          break
         }
       }
     }
 
     return {
-      score: carouselCount === 0 ? 1 : 0,
+      score: carouselUrls.length === 0 ? 1 : 0,
       displayValue:
-        carouselCount === 0
+        carouselUrls.length === 0
           ? str_(UIStrings.displayValuePass)
-          : str_(UIStrings.displayValueFail, { count: carouselCount }),
-      numericValue: carouselCount,
+          : str_(UIStrings.displayValueFail, { count: carouselUrls.length }),
+      numericValue: carouselUrls.length,
       numericUnit: 'unitless' as
         | 'unitless'
         | 'byte'
         | 'millisecond'
         | 'element',
+      details: {
+        type: 'table' as const,
+        headings: [
+          {
+            key: 'url',
+            label: str_(UIStrings.colLabelUrl),
+            valueType: 'url' as const,
+          },
+        ],
+        items: carouselUrls.map(url => ({ url })),
+      } as LH.Audit.Details.Table,
     }
   }
 }

--- a/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-cookie-on-static.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-cookie-on-static.ts
@@ -11,6 +11,7 @@ const UIStrings = {
     'Avoid sending cookies with static resources (images, CSS, JS, fonts). [See RWEB_0081](https://rweb.greenit.fr/en/fiches/RWEB_0081-host-static-resources-on-a-cookie-free-domain)',
   displayValuePass: 'No static resources with Cookie header',
   displayValueFail: '{count} static resource(s) sent with Cookie header',
+  colLabelUrl: 'Resource URL',
 }
 const str_ = createIcuMessageFn(
   'audits/bp/rweb-no-cookie-on-static.js',
@@ -61,6 +62,17 @@ class BPRwebNoCookieOnStatic extends Audit {
         | 'byte'
         | 'millisecond'
         | 'element',
+      details: {
+        type: 'table' as const,
+        headings: [
+          {
+            key: 'url',
+            label: str_(UIStrings.colLabelUrl),
+            valueType: 'url' as const,
+          },
+        ],
+        items: staticWithCookie.map(r => ({ url: r.url })),
+      } as LH.Audit.Details.Table,
     }
   }
 }

--- a/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-gif.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-gif.ts
@@ -9,6 +9,7 @@ import {
 import { Audit, NetworkRecords } from 'lighthouse'
 import { NetworkRequest } from 'lighthouse/core/lib/network-request.js'
 import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'
+
 const UIStrings = {
   title: 'RWEB_0099 - Avoid using GIFs',
   failureTitle: 'RWEB_0099 - GIFs detected',
@@ -16,6 +17,7 @@ const UIStrings = {
     'Avoid using GIFs for animations or images; use modern formats instead. [See RWEB_0099](https://rweb.greenit.fr/en/fiches/RWEB_0099-limit-the-use-of-animated-gif)',
   displayValuePass: 'No GIFs detected',
   displayValueFail: '{count} GIF(s) detected',
+  colLabelUrl: 'GIF URL',
 }
 const str_ = createIcuMessageFn('audits/bp/rweb-no-gif.js', UIStrings)
 
@@ -41,22 +43,20 @@ class BPRwebNoGif extends Audit {
     )
     const html = artifacts.MainDocumentContent || ''
 
-    let gifCount = 0
-
-    // Check network records for .gif URLs
+    const gifRecords: string[] = []
     for (const record of networkRecords) {
       if (NetworkRequest.isNonNetworkRequest(record)) continue
       if (record.url.toLowerCase().endsWith('.gif')) {
-        gifCount++
+        gifRecords.push(record.url)
       }
     }
 
-    // Check HTML for inline <img> tags with .gif src
-    const gifPattern = /src\s*=\s*["']([^"']*\.gif)["']/gi
-    const matches = html.match(gifPattern)
-    if (matches) {
-      gifCount += matches.length
-    }
+    // Count inline <img src="*.gif"> in HTML for the score only (paths are relative, not listable as URLs)
+    const htmlGifPattern = /src\s*=\s*["']([^"']*\.gif)["']/gi
+    const htmlMatches = html.match(htmlGifPattern)
+    const htmlGifCount = htmlMatches ? htmlMatches.length : 0
+
+    const gifCount = gifRecords.length + htmlGifCount
 
     return {
       score: gifCount === 0 ? 1 : 0,
@@ -70,6 +70,17 @@ class BPRwebNoGif extends Audit {
         | 'byte'
         | 'millisecond'
         | 'element',
+      details: {
+        type: 'table' as const,
+        headings: [
+          {
+            key: 'url',
+            label: str_(UIStrings.colLabelUrl),
+            valueType: 'url' as const,
+          },
+        ],
+        items: gifRecords.map(url => ({ url })),
+      } as LH.Audit.Details.Table,
     }
   }
 }

--- a/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-inline-assets.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-inline-assets.ts
@@ -16,6 +16,8 @@ const UIStrings = {
     'Minimize the use of inline scripts and styles. [See RWEB_0042](https://rweb.greenit.fr/en/fiches/RWEB_0042-externalize-css-and-javascript)',
   displayValuePass: 'No inline assets',
   displayValueFail: '{count} inline asset(s) found',
+  colLabelType: 'Type',
+  colLabelSnippet: 'Snippet',
 }
 const str_ = createIcuMessageFn('audits/bp/rweb-no-inline-assets.js', UIStrings)
 
@@ -35,8 +37,14 @@ class BPRwebNoInlineAssets extends Audit {
   }
 
   static audit(artifacts: LH.Artifacts & BPArtifacts) {
-    const { inlineScripts, inlineStyles } = artifacts.BPGatherer
-    const totalInlineAssets = inlineScripts + inlineStyles
+    const { inlineScriptDetails, inlineStyleDetails } = artifacts.BPGatherer
+    const totalInlineAssets =
+      inlineScriptDetails.length + inlineStyleDetails.length
+
+    const items = [
+      ...inlineScriptDetails.map(d => ({ type: 'script', snippet: d.snippet })),
+      ...inlineStyleDetails.map(d => ({ type: 'style', snippet: d.snippet })),
+    ]
 
     return {
       score: totalInlineAssets <= 2 ? 1 : 0,
@@ -50,6 +58,24 @@ class BPRwebNoInlineAssets extends Audit {
         | 'byte'
         | 'millisecond'
         | 'element',
+      ...(totalInlineAssets > 0 && {
+        details: {
+          type: 'table' as const,
+          headings: [
+            {
+              key: 'type',
+              label: str_(UIStrings.colLabelType),
+              valueType: 'text' as const,
+            },
+            {
+              key: 'snippet',
+              label: str_(UIStrings.colLabelSnippet),
+              valueType: 'text' as const,
+            },
+          ],
+          items,
+        } as LH.Audit.Details.Table,
+      }),
     }
   }
 }

--- a/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-redirects.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-redirects.ts
@@ -18,6 +18,8 @@ const UIStrings = {
   description:
     'Reduce HTTP redirects to avoid unnecessary round trips. [See RWEB_0112](https://rweb.greenit.fr/en/fiches/RWEB_0112-avoir-redirections)',
   displayValue: '{count} redirect(s)',
+  colLabelUrl: 'URL',
+  colLabelStatus: 'HTTP Status',
 }
 const str_ = createIcuMessageFn('audits/bp/rweb-no-redirects.js', UIStrings)
 
@@ -52,6 +54,25 @@ class BPRwebNoRedirects extends Audit {
         | 'byte'
         | 'millisecond'
         | 'element',
+      details: {
+        type: 'table' as const,
+        headings: [
+          {
+            key: 'url',
+            label: str_(UIStrings.colLabelUrl),
+            valueType: 'url' as const,
+          },
+          {
+            key: 'statusCode',
+            label: str_(UIStrings.colLabelStatus),
+            valueType: 'text' as const,
+          },
+        ],
+        items: redirects.map(r => ({
+          url: r.url,
+          statusCode: String(r.statusCode),
+        })),
+      } as LH.Audit.Details.Table,
     }
   }
 }

--- a/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-social-sdk.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-social-sdk.ts
@@ -24,6 +24,7 @@ const UIStrings = {
   description:
     'Replace official social network buttons with static links to reduce third-party requests. [See RWEB_0059](https://rweb.greenit.fr/en/fiches/RWEB_0059-replace-the-official-social-network-sharing-buttons)',
   displayValue: '{count} social SDK request(s) detected',
+  colLabelUrl: 'SDK URL',
 }
 const str_ = createIcuMessageFn('audits/bp/rweb-no-social-sdk.js', UIStrings)
 
@@ -58,6 +59,17 @@ class BPRwebNoSocialSdk extends Audit {
         | 'byte'
         | 'millisecond'
         | 'element',
+      details: {
+        type: 'table' as const,
+        headings: [
+          {
+            key: 'url',
+            label: str_(UIStrings.colLabelUrl),
+            valueType: 'url' as const,
+          },
+        ],
+        items: sdkRequests.map(r => ({ url: r.url })),
+      } as LH.Audit.Details.Table,
     }
   }
 }

--- a/libs/ecoindex-lh-plugin-ts/src/gatherers/bp-gatherer.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/gatherers/bp-gatherer.ts
@@ -4,7 +4,7 @@ import { Gatherer } from 'lighthouse'
 
 class BPGatherer extends Gatherer {
   meta: LH.Gatherer.GathererMeta = {
-    supportedModes: ['navigation', 'timespan', 'snapshot'],
+    supportedModes: ['navigation', 'timespan', 'snapshot'] as const,
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/libs/ecoindex-lh-plugin-ts/src/gatherers/bp-gatherer.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/gatherers/bp-gatherer.ts
@@ -15,18 +15,25 @@ class BPGatherer extends Gatherer {
     function collectBPData() {
       if (typeof document === 'undefined') {
         return {
-          autoplaying: 0,
           serviceWorkerActive: false,
-          canvasCount: 0,
-          inlineScripts: 0,
-          inlineStyles: 0,
-          animatedElements: 0,
+          inlineScriptDetails: [],
+          inlineStyleDetails: [],
+          animatedElementDetails: [],
+          autoplayDetails: [],
+          canvasDetails: [],
         }
       }
 
-      const autoplaying = document.querySelectorAll(
-        'video[autoplay], audio[autoplay], video[preload="auto"], audio[preload="auto"]',
-      ).length
+      const SNIPPET_LEN = 120
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      function buildSelector(el: any) {
+        let sel = el.tagName.toLowerCase()
+        if (el.id) sel += `#${el.id}`
+        if (el.classList.length > 0)
+          sel += '.' + Array.from(el.classList).join('.')
+        return sel
+      }
 
       const serviceWorkerActive = Boolean(
         'serviceWorker' in navigator &&
@@ -34,23 +41,26 @@ class BPGatherer extends Gatherer {
         navigator.serviceWorker.controller,
       )
 
-      const canvasCount = document.querySelectorAll('canvas').length
-
-      const inlineScripts = Array.from(
+      const inlineScriptDetails = Array.from(
         document.querySelectorAll('script:not([src])'),
-      ).filter(
-        s =>
-          s.getAttribute('type') !== 'application/ld+json' &&
-          (s.textContent || '').trim().length > 0,
-      ).length
+      )
+        .filter(
+          s =>
+            s.getAttribute('type') !== 'application/ld+json' &&
+            (s.textContent || '').trim().length > 0,
+        )
+        .map(s => ({
+          snippet: (s.textContent || '').trim().slice(0, SNIPPET_LEN),
+        }))
 
-      const inlineStyles = Array.from(
-        document.querySelectorAll('style'),
-      ).filter(s => (s.textContent || '').trim().length > 0).length
+      const inlineStyleDetails = Array.from(document.querySelectorAll('style'))
+        .filter(s => (s.textContent || '').trim().length > 0)
+        .map(s => ({
+          snippet: (s.textContent || '').trim().slice(0, SNIPPET_LEN),
+        }))
 
-      let animatedElements = 0
-      const allElements = Array.from(document.querySelectorAll('*'))
-      for (const el of allElements) {
+      const animatedElementDetails = []
+      for (const el of Array.from(document.querySelectorAll('*'))) {
         const cs = window.getComputedStyle(el)
         const hasAnimation =
           cs.animationName !== 'none' && cs.animationName !== ''
@@ -58,16 +68,34 @@ class BPGatherer extends Gatherer {
           cs.transitionProperty !== 'none' &&
           cs.transitionProperty !== '' &&
           cs.transitionDuration !== '0s'
-        if (hasAnimation || hasTransition) animatedElements++
+        if (hasAnimation || hasTransition) {
+          const property = hasAnimation
+            ? `animation: ${cs.animationName}`
+            : `transition: ${cs.transitionProperty}`
+          animatedElementDetails.push({ selector: buildSelector(el), property })
+        }
       }
 
+      const autoplayDetails = Array.from(
+        document.querySelectorAll(
+          'video[autoplay], audio[autoplay], video[preload="auto"], audio[preload="auto"]',
+        ),
+      ).map(el => ({
+        selector: buildSelector(el),
+        src: el.getAttribute('src') || '',
+      }))
+
+      const canvasDetails = Array.from(document.querySelectorAll('canvas')).map(
+        el => ({ selector: buildSelector(el) }),
+      )
+
       return {
-        autoplaying,
         serviceWorkerActive,
-        canvasCount,
-        inlineScripts,
-        inlineStyles,
-        animatedElements,
+        inlineScriptDetails,
+        inlineStyleDetails,
+        animatedElementDetails: animatedElementDetails.slice(0, 50),
+        autoplayDetails,
+        canvasDetails,
       }
     }
 

--- a/libs/ecoindex-lh-plugin-ts/src/gatherers/dom-informations.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/gatherers/dom-informations.ts
@@ -16,7 +16,7 @@ import { getVersion } from '../utils/index.js'
  */
 class DOMInformations extends Gatherer {
   meta: LH.Gatherer.GathererMeta = {
-    supportedModes: ['navigation', 'timespan', 'snapshot'],
+    supportedModes: ['navigation', 'timespan', 'snapshot'] as const,
   }
 
   /**

--- a/libs/ecoindex-lh-plugin-ts/src/helpers/lhci/custom-config.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/helpers/lhci/custom-config.ts
@@ -39,5 +39,5 @@ export default {
         implementation: bpGatherer,
       },
     },
-  ] as const,
+  ],
 }

--- a/libs/ecoindex-lh-plugin-ts/src/helpers/lhci/custom-config.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/helpers/lhci/custom-config.ts
@@ -39,5 +39,5 @@ export default {
         implementation: bpGatherer,
       },
     },
-  ],
+  ] as const,
 }

--- a/libs/ecoindex-lh-plugin-ts/src/types/index.d.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/types/index.d.ts
@@ -60,10 +60,10 @@ export interface BPArtifacts extends Artifacts {
 }
 
 export interface BPGathererResult {
-  autoplaying: number
   serviceWorkerActive: boolean
-  canvasCount: number
-  inlineScripts: number
-  inlineStyles: number
-  animatedElements: number
+  inlineScriptDetails: { snippet: string }[]
+  inlineStyleDetails: { snippet: string }[]
+  animatedElementDetails: { selector: string; property: string }[]
+  autoplayDetails: { selector: string; src: string }[]
+  canvasDetails: { selector: string }[]
 }

--- a/test/test-ecoindex-lh-cli/input-file.json
+++ b/test/test-ecoindex-lh-cli/input-file.json
@@ -38,6 +38,13 @@
       "urls": ["http://localhost:3000/heavy"]
     },
     {
+      "name": "BP Violations Test",
+      "target": "Test BP audit violations detection",
+      "course": "Verify that BP audits correctly detect inline assets, animations, canvas, autoplay, GIFs and other violations",
+      "is-best-pages": false,
+      "urls": ["http://localhost:3000/bp-violations"]
+    },
+    {
       "name": "Complete Test Suite",
       "target": "Run all test pages",
       "course": "Full validation of DOM counting logic",

--- a/test/test-ecoindex-lh-cli/package.json
+++ b/test/test-ecoindex-lh-cli/package.json
@@ -10,7 +10,7 @@
     "test": "pnpm test:input-json && pnpm test:url",
     "test:input-json": "pnpm --filter @ecoindex-lh-test/cli run npx collect --json-file ./input-file.json && pnpm verify:file",
     "test:demo": "pnpm --filter @ecoindex-lh-test/cli run npx collect --demo",
-    "test:url": "pnpm --filter @ecoindex-lh-test/cli run npx collect -u http://localhost:3000/simple -u http://localhost:3000/svg -u http://localhost:3000/shadow-dom -u http://localhost:3000/svg-shadow-dom -u http://localhost:3000/complex -u http://localhost:3000/heavy --output html --output json --puppeteer-script ./puppeteer-script.mjs --extra-header ./extra-header.json --lang fr && pnpm verify:url",
+    "test:url": "pnpm --filter @ecoindex-lh-test/cli run npx collect -u http://localhost:3000/simple -u http://localhost:3000/svg -u http://localhost:3000/shadow-dom -u http://localhost:3000/svg-shadow-dom -u http://localhost:3000/complex -u http://localhost:3000/heavy -u http://localhost:3000/bp-violations --output html --output json --puppeteer-script ./puppeteer-script.mjs --extra-header ./extra-header.json --lang fr && pnpm verify:url",
     "test:help": "pnpm --filter @ecoindex-lh-test/cli run npx collect --help",
     "verify:file": "node ../test-pages/verify-results.js ./reports/file",
     "verify:url": "node ../test-pages/verify-results.js ./reports",


### PR DESCRIPTION
## Summary

- Extends `BPGatherer` to return typed arrays of element details (inline scripts/styles, animated elements, autoplay media, canvas) instead of integer counters
- Updates 4 Groupe 1 audits (`rweb-no-inline-assets`, `rweb-no-animations`, `rweb-no-autoplay`, `rweb-no-canvas`) to use the new arrays and expose a conditional `details` table when violations are found
- Adds an always-present `details` table to 8 Groupe 2 audits (`rweb-limit-domains`, `rweb-limit-fonts`, `rweb-limit-analytics`, `rweb-no-gif`, `rweb-no-redirects`, `rweb-no-cookie-on-static`, `rweb-no-social-sdk`, `rweb-no-carousel`) using data already available in each audit
- Adds `bp-violations` page to the CLI test suite (`input-file.json` + `test:url` script)

Previously, these audits only reported a count — the user could see *how many* violations existed but not *which* elements were responsible. Each audit now surfaces a structured table in the Lighthouse report.