### PR TITLE
docs: RWEB coherence analysis, corrections PRD, and Phase 1 plan

### DIFF
--- a/.superpowers/specs/2026-05-28-rweb-backlog-design.md
+++ b/.superpowers/specs/2026-05-28-rweb-backlog-design.md
@@ -1,0 +1,373 @@
+# Design — Backlog RWEB : corrections + nouveaux audits
+
+**Date** : 2026-05-28  
+**Sources** : `todo/rapport-coherence-rweb.md` · `todo/rweb-fiches-non-implementees-testables.md`  
+**Lib cible** : `libs/ecoindex-lh-plugin-ts`
+
+---
+
+## Contexte
+
+Deux analyses ont été menées sur le référentiel RWEB (119 fiches MCP GreenIT) :
+
+1. **Rapport de cohérence** — 39 audits existants audités contre leur fiche RWEB : 5 incohérences critiques, 17 partiels, 10 alignés, 7 sans correspondance RWEB.
+2. **Fiches non implémentées** — 86 fiches restantes dont 17 clairement testables via navigateur, 8 partiellement testables.
+
+Ce document organise le backlog en deux parties : corrections des audits existants, puis implémentation des nouveaux audits par ordre de priorité.
+
+---
+
+## Partie 1 — Corrections des audits existants
+
+### 1.1 `rweb-css-containment` → remapping sur RWEB_0052 (P1 🔴)
+
+**Problème** : l'audit compte les fichiers CSS chargés (`scoreDisplayMode: 'manual'`), ce qui correspond à RWEB_0052, pas à RWEB_0039 (propriété CSS `contain`).
+
+**Actions** :
+
+- Option A — Remapper l'audit sur `RWEB_0052`, mettre à jour `id`, `title`, l'entrée dans `plugin.ts` et `refs-urls.ts`
+- Option B — Implémenter la vraie détection RWEB_0039 : vérifier via CDP ou `getComputedStyle` que les éléments clés du DOM utilisent la propriété `contain`
+
+**Recommandation** : Option A (Option B nécessite un gatherer CDP dédié). Créer ensuite un vrai audit `rweb-css-containment` (RWEB_0039) séparément.
+
+**Fichiers** :
+
+- `audits/bp/rweb-css-containment.ts` — mise à jour `id` et `title`
+- `plugin.ts` — mise à jour `auditRefs`
+- `locales/fr.json` — mise à jour clés
+
+---
+
+### 1.2 `rweb-no-document-write` → corriger le mapping RWEB (P1 🔴)
+
+**Problème** : l'audit détecte l'usage de l'API `doc-write` dans les scripts inline. Or RWEB_0044 concerne les modifications DOM pendant une traversée d'arbre (boucle sur `childNodes`), ce qui est différent.
+
+**Actions** :
+
+- Identifier la fiche RWEB correcte pour cette API (candidat : RWEB_0057 — réduire les accès DOM via JS)
+- Mettre à jour `title`, `description`, l'ID RWEB référencé, et `refs-urls.ts`
+
+**Fichiers** :
+
+- `audits/bp/rweb-no-document-write.ts`
+- `plugin.ts`
+- `locales/fr.json`
+
+---
+
+### 1.3 `rweb-combine-assets` → aligner les seuils sur la fiche (P1 🔴)
+
+**Problème** : l'audit score 1 si ≤ 10 fichiers, 0.5 si ≤ 15, 0 sinon. Or RWEB_0078 indique `maxValue: 2` — un écart de 5× à 7×. C'est une incohérence critique : un site avec 9 fichiers CSS+JS obtiendrait score 1 alors que la fiche le classerait en échec.
+
+**Actions** :
+
+- Aligner sur `maxValue = 2` ou documenter explicitement l'écart avec un commentaire WHY si le seuil RWEB est jugé trop contraignant pour le contexte réel
+
+**Fichiers** :
+
+- `audits/bp/rweb-combine-assets.ts`
+
+---
+
+### 1.4 `rweb-minification` → étendre aux fichiers externes (P2 🟡)
+
+**Problème** : l'audit ne vérifie que les blocs `<style>` et `<script>` inline. RWEB_0077 couvre tous les assets.
+
+**Actions** :
+
+- Ajouter une vérification sur les `NetworkRecords` : détecter les ressources CSS/JS sans `Content-Encoding` gzip/br ET dont le `transferSize > resourceSize * 0.9` (heuristique : non minifié)
+- Maintenir la détection inline existante
+
+**Fichiers** :
+
+- `audits/bp/rweb-minification.ts`
+
+---
+
+### 1.5 `rweb-cache-control` → vérifier la valeur `max-age` (P3 🟡)
+
+**Problème** : l'audit vérifie la présence du header, pas sa valeur. Un `max-age=0` est un faux positif.
+
+**Actions** :
+
+- Parser `Cache-Control` et vérifier `max-age > 0` (ou présence de `immutable`)
+- Exclure les ressources sans cache attendu (ex. HTML)
+
+**Fichiers** :
+
+- `audits/bp/rweb-cache-control.ts`
+
+---
+
+### 1.6 `rweb-no-hidden-images` → étendre à `visibility:hidden` et `opacity:0` (P3 🟡)
+
+**Problème** : seul `display:none` est détecté. Les deux autres techniques cachent visuellement une image tout en la chargeant.
+
+**Actions** :
+
+- Dans `executionContext.evaluate`, ajouter la détection via `getComputedStyle(el).visibility === 'hidden'` et `getComputedStyle(el).opacity === '0'`
+
+**Fichiers** :
+
+- `gatherers/bp-gatherer.ts` (ou logique inline dans l'audit selon l'implémentation actuelle)
+- `audits/bp/rweb-no-hidden-images.ts`
+
+---
+
+### 1.7 `rweb-no-unused-code` → corriger le mapping RWEB_0046 (P1 🔴)
+
+**Problème** : l'audit détecte les `<script src="...">` sans `async` ou `defer` (scripts bloquants). RWEB_0046 concerne les ressources chargées qui ne sont pas immédiatement utilisées — notion distincte du mode de chargement.
+
+**Actions** :
+
+- Remapper l'audit sur une fiche RWEB relative au render-blocking (ou créer un intitulé autonome)
+- Créer un audit distinct `rweb-library-coverage` (RWEB_0015) via Coverage API pour la vraie détection de ressources inutiles
+
+**Fichiers** :
+
+- `audits/bp/rweb-no-unused-code.ts` — mise à jour `title`, `description`, ID RWEB référencé
+- `locales/fr.json` — mise à jour clés
+- `refs-urls.ts`
+
+---
+
+### 1.8 `rweb-no-js-errors` → corriger le mapping RWEB_0043 (P1 🔴)
+
+**Problème** : l'audit détecte les `ConsoleMessages` de niveau `error` (erreurs runtime JS). RWEB_0043 concerne les lignes non validées par ESLint (`maxValue = 0` lignes en erreur ESLint) — analyse statique, non détectable par Lighthouse.
+
+**Actions** :
+
+- Option A — Remapper sur une fiche de qualité runtime (il n'en existe pas d'exacte dans RWEB — créer en BP autonome)
+- Option B — Renommer le titre pour refléter l'usage réel : « No JS runtime errors in console »
+
+**Recommandation** : Option B, plus simple. Supprimer la référence RWEB_0043 ou la marquer comme approximative.
+
+**Fichiers** :
+
+- `audits/bp/rweb-no-js-errors.ts` — mise à jour `title`, `description`
+- `locales/fr.json` — mise à jour clés
+
+---
+
+### 1.9 `rweb-lazy-loading` → restreindre aux images below-the-fold (P2 🟡)
+
+**Problème** : l'audit pénalise _toutes_ les images sans `loading="lazy"`, y compris les images above-the-fold. La fiche RWEB_0051 concerne uniquement les éléments hors viewport initial. Les iframes et vidéos sont aussi ignorées.
+
+**Actions** :
+
+- Exclure les images dans la première fenêtre via un gatherer CDP (`getBoundingClientRect().top < window.innerHeight`)
+- Étendre aux `<iframe>` et `<video>` sans `loading="lazy"`
+
+**Fichiers** :
+
+- `audits/bp/rweb-lazy-loading.ts`
+
+---
+
+### 1.10 `rweb-no-animations` → aligner le seuil sur la fiche (P2 🟡)
+
+**Problème** : score 0 dès la première animation détectée. La fiche RWEB_0009 tolère jusqu'à 2 animations (`maxValue = 2`).
+
+**Actions** :
+
+- Modifier le seuil : score 1 si ≤ 2 animations, 0 sinon
+
+**Fichiers** :
+
+- `audits/bp/rweb-no-animations.ts`
+
+---
+
+### 1.11 `rweb-no-autoplay` → ajouter la vérification de `preload="none"` (P2 🟡)
+
+**Problème** : seul l'attribut `autoplay` est vérifié. La fiche RWEB_0106 couvre aussi les éléments sans `preload="none"`. Un `<video>` sans `autoplay` mais avec `preload="eager"` charge les médias inutilement.
+
+**Actions** :
+
+- Dans BPGatherer, étendre `autoplayDetails` pour inclure les `<video>/<audio>` sans `preload="none"`
+
+**Fichiers** :
+
+- `gatherers/bp-gatherer.ts` — logique `autoplayDetails`
+- `audits/bp/rweb-no-autoplay.ts`
+
+---
+
+### 1.12 `rweb-no-cookie-on-static` → passer au comptage par domaine (P2 🟡)
+
+**Problème** : l'audit compte le nombre de _ressources_ individuelles avec cookie. La fiche RWEB*0081 mesure le nombre de \_domaines* servant des ressources statiques avec cookie (`maxValue = 1`).
+
+**Actions** :
+
+- Grouper les violations par `hostname` et compter les domaines uniques
+- Score 1 si ≤ 1 domaine, 0 sinon
+
+**Fichiers** :
+
+- `audits/bp/rweb-no-cookie-on-static.ts`
+
+---
+
+## Partie 2 — Nouveaux audits RWEB
+
+Triés par score impact × priorité. Chaque audit suit le pattern standard : fichier TS dans `audits/bp/`, entrée dans `plugin.ts`, traductions dans `locales/fr.json`, référence dans `refs-urls.ts`.
+
+### Tier 1 — Clairement testables (17 fiches)
+
+| Rang | ID        | Titre                                     | Source de données                     | Seuil RWEB                         |
+| ---- | --------- | ----------------------------------------- | ------------------------------------- | ---------------------------------- |
+| 1    | RWEB_0015 | Portions indispensables des bibliothèques | Coverage API (NetworkRecords)         | ≤ 1 lib avec portions inutiles     |
+| 2    | RWEB_0052 | Réduire repaint et reflow                 | Performance API / CSS CDP             | ≤ 1 modification causant repaint   |
+| 3    | RWEB_0048 | Dimensionner correctement les images      | `naturalWidth/Height` vs affiché CDP  | KB inutiles < 5% du total          |
+| 4    | RWEB_0098 | Optimiser les médias avant import CMS     | NetworkRecords + heuristique CMS      | 0 média non optimisé               |
+| 5    | RWEB_0021 | Limiter les appels API HTTP               | NetworkRecords XHR/fetch              | 0 endpoint sans cache              |
+| 6    | RWEB_0030 | Transcription textuelle des médias        | DOM `<track>` sur `<video>`/`<audio>` | < 10% de médias sans transcription |
+| 7    | RWEB_0053 | Éviter les blocages JS (TBT)              | Lighthouse `total-blocking-time`      | TBT ≤ 200 ms                       |
+| 8    | RWEB_0047 | Limiter le nombre de requêtes HTTP        | NetworkRecords count                  | ≤ 40 requêtes                      |
+| 9    | RWEB_0074 | Utiliser un cache HTTP                    | NetworkRecords headers                | 0 header sans cache                |
+| 10   | RWEB_0049 | Optimiser les images                      | NetworkRecords MIME type              | 0 JPEG/PNG remplaçable par WebP    |
+| 11   | RWEB_0050 | Préférer les glyphes aux images           | DOM images ≤ 32×32 px monochromes     | 0 image remplaçable par glyphe     |
+| 12   | RWEB_0056 | Utiliser la délégation d'événements       | CDP `DOMDebugger.getEventListeners`   | 0 listener sans délégation         |
+| 13   | RWEB_0013 | Pagination plutôt que défilement infini   | DOM IntersectionObserver heuristique  | < 10% de listes sans pagination    |
+| 14   | RWEB_0064 | Stocker les données statiques localement  | `window.localStorage` / `caches`      | < 25% de données non cachées       |
+| 15   | RWEB_0008 | Navigation rapide dans l'historique       | Lighthouse `uses-long-cache-ttl`      | 0 page inéligible bfcache          |
+| 16   | RWEB_0096 | Choisir un hébergeur éco-responsable      | TheGreenWebFoundation API             | PUE ≤ 1.5                          |
+| 17   | RWEB_0057 | Réduire les accès DOM via JS              | AST JS inline                         | 0 accès sans variable locale       |
+
+#### Détails — audits prioritaires
+
+**RWEB_0015 — Portions indispensables des bibliothèques**
+
+- Artefact : `ScriptElements` + `Coverage` (si disponible)
+- Logique : pour chaque script externe connu (jQuery, lodash, moment…), comparer `usedBytes / totalBytes` — score 0 si ratio < 0.5 sur ≥ 1 lib
+- Table : `[{ url, used, total, ratio }]`
+
+**RWEB_0048 — Dimensionner correctement les images**
+
+- Nécessite un gatherer CDP : `Runtime.evaluate` avec `getBoundingClientRect` + `naturalWidth/naturalHeight`
+- Logique : `wastedBytes = (naturalWidth * naturalHeight - displayWidth * displayHeight) * bytesPerPixel`
+- Score 0 si `wastedBytes > 5% du total images`
+
+**RWEB_0053 — Éviter les blocages JS (TBT)**
+
+- Wrapper de l'audit Lighthouse natif `total-blocking-time`
+- Score 1 si TBT ≤ 200 ms, 0 sinon
+
+**RWEB_0030 — Transcription textuelle des médias**
+
+- Logique : `querySelectorAll('video, audio')` → vérifier présence `<track kind="captions|subtitles">`
+- Score 0 si ≥ 10% des médias sans `<track>`
+
+**RWEB_0074 — Utiliser un cache HTTP**
+
+- Logique : NetworkRecords → ressources sans `Cache-Control` ni `ETag` ni `Last-Modified`
+- Exclure les ressources `no-store` intentionnelles
+
+---
+
+### Tier 2 — Partiellement testables (8 fiches)
+
+| ID        | Titre                                        | Limite principale                                                |
+| --------- | -------------------------------------------- | ---------------------------------------------------------------- |
+| RWEB_0004 | Approche mobile first                        | Heuristique : viewport meta + media queries CSS                  |
+| RWEB_0003 | Supprimer les fonctionnalités non utilisées  | Coverage API → % JS non exécuté (pas les fonctionnalités métier) |
+| RWEB_0007 | Traitement asynchrone                        | Détecter `XMLHttpRequest` synchrone dans JS inline               |
+| RWEB_0045 | Éléments DOM invisibles lors de modification | MutationObserver sur éléments `display:none`                     |
+| RWEB_0070 | Utiliser un CDN                              | Détecter headers CDN (`CF-Ray`, `X-Served-By`, etc.)             |
+| RWEB_0072 | Mettre en cache les réponses AJAX            | `Cache-Control` sur réponses XHR/fetch (complète RWEB_0074)      |
+| RWEB_0061 | Valider les pages W3C                        | Parser HTML, détecter erreurs structurelles courantes            |
+| RWEB_0090 | Mettre en place un sitemap efficient         | Fetch `/sitemap.xml`, vérifier présence et structure             |
+
+---
+
+## Fichiers à créer / modifier
+
+| Fichier                                 | Action                                       |
+| --------------------------------------- | -------------------------------------------- |
+| `audits/bp/rweb-css-containment.ts`     | Remapping RWEB_0052 (correction P1 🔴)       |
+| `audits/bp/rweb-no-document-write.ts`   | Correction mapping RWEB_0044 (P1 🔴)         |
+| `audits/bp/rweb-combine-assets.ts`      | Alignement seuils maxValue=2 (P1 🔴)         |
+| `audits/bp/rweb-no-unused-code.ts`      | Correction mapping RWEB_0046 (P1 🔴)         |
+| `audits/bp/rweb-no-js-errors.ts`        | Correction mapping RWEB_0043 (P1 🔴)         |
+| `audits/bp/rweb-minification.ts`        | Extension NetworkRecords (P2 🟡)             |
+| `audits/bp/rweb-cache-control.ts`       | Vérification max-age + Expires (P2 🟡)       |
+| `audits/bp/rweb-no-hidden-images.ts`    | Extension visibility/opacity (P3 🟡)         |
+| `audits/bp/rweb-lazy-loading.ts`        | Restreindre aux images below-fold (P2 🟡)    |
+| `audits/bp/rweb-no-animations.ts`       | Aligner seuil maxValue=2 (P2 🟡)             |
+| `audits/bp/rweb-no-autoplay.ts`         | Ajouter vérif preload="none" (P2 🟡)         |
+| `audits/bp/rweb-no-cookie-on-static.ts` | Passer au comptage par domaine (P2 🟡)       |
+| `gatherers/bp-gatherer.ts`              | Extension autoplayDetails (P2 🟡)            |
+| `audits/bp/rweb-library-coverage.ts`    | Nouveau — RWEB_0015                          |
+| `audits/bp/rweb-image-sizing.ts`        | Nouveau — RWEB_0048                          |
+| `audits/bp/rweb-optimize-images.ts`     | Nouveau — RWEB_0049                          |
+| `audits/bp/rweb-prefer-glyphs.ts`       | Nouveau — RWEB_0050                          |
+| `audits/bp/rweb-total-blocking-time.ts` | Nouveau — RWEB_0053 (wrapper LH natif)       |
+| `audits/bp/rweb-event-delegation.ts`    | Nouveau — RWEB_0056 (CDP)                    |
+| `audits/bp/rweb-media-transcription.ts` | Nouveau — RWEB_0030                          |
+| `audits/bp/rweb-http-requests.ts`       | Nouveau — RWEB_0047                          |
+| `audits/bp/rweb-http-cache.ts`          | Nouveau — RWEB_0074                          |
+| `audits/bp/rweb-pagination.ts`          | Nouveau — RWEB_0013 (heuristique)            |
+| `audits/bp/rweb-local-storage.ts`       | Nouveau — RWEB_0064                          |
+| `audits/bp/rweb-bfcache.ts`             | Nouveau — RWEB_0008 (wrapper LH natif)       |
+| `audits/bp/rweb-api-cache.ts`           | Nouveau — RWEB_0021                          |
+| `audits/bp/rweb-dom-access.ts`          | Nouveau — RWEB_0057 (AST inline)             |
+| `plugin.ts`                             | Enregistrement de tous les nouveaux audits   |
+| `locales/fr.json`                       | Traductions FR pour tous les nouveaux audits |
+| `refs-urls.ts`                          | Ajout des nouveaux IDs RWEB                  |
+
+---
+
+## Ordre d'implémentation recommandé
+
+```
+Phase 1 — Corrections critiques P1 🔴 (mapping erroné ou seuil critique)
+  1. rweb-combine-assets : aligner seuils sur maxValue=2 (RWEB_0078)
+  2. rweb-no-document-write : corriger mapping RWEB_0044
+  3. rweb-css-containment : remapping RWEB_0052
+  4. rweb-no-unused-code : corriger mapping RWEB_0046 (scripts bloquants ≠ ressources inutiles)
+  5. rweb-no-js-errors : corriger mapping RWEB_0043 (runtime errors ≠ ESLint)
+
+Phase 2 — Corrections partielles P2 🟡
+  6.  rweb-lazy-loading : restreindre aux images below-fold + iframes/vidéos
+  7.  rweb-no-animations : aligner seuil sur maxValue=2
+  8.  rweb-no-autoplay : ajouter vérif preload="none"
+  9.  rweb-no-cookie-on-static : passer au comptage par domaine
+  10. rweb-minification : extension aux fichiers CSS/JS externes (NetworkRecords)
+  11. rweb-cache-control : vérification max-age > 0 + header Expires
+  12. rweb-no-hidden-images : extension visibility/opacity
+
+Phase 3 — Nouveaux audits simples (NetworkRecords ou DOM)
+  13. RWEB_0047 rweb-http-requests
+  14. RWEB_0030 rweb-media-transcription
+  15. RWEB_0049 rweb-optimize-images
+  16. RWEB_0050 rweb-prefer-glyphs
+  17. RWEB_0074 rweb-http-cache
+  18. RWEB_0013 rweb-pagination
+
+Phase 4 — Wrappers Lighthouse natifs
+  19. RWEB_0053 rweb-total-blocking-time
+  20. RWEB_0008 rweb-bfcache
+
+Phase 5 — Nouveaux audits avec gatherer/CDP
+  21. RWEB_0015 rweb-library-coverage (Coverage API)
+  22. RWEB_0048 rweb-image-sizing (CDP getBoundingClientRect)
+  23. RWEB_0056 rweb-event-delegation (CDP getEventListeners)
+  24. RWEB_0064 rweb-local-storage
+  25. RWEB_0021 rweb-api-cache
+
+Phase 6 — Tier 2 (heuristiques, post-validation)
+  26–33. RWEB_0004, RWEB_0003, RWEB_0007, RWEB_0045, RWEB_0070, RWEB_0072, RWEB_0061, RWEB_0090
+```
+
+---
+
+## Risques et limites
+
+| Point                     | Détail                                                                                                 |
+| ------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Coverage API              | Non disponible par défaut dans Lighthouse — nécessite un gatherer CDP dédié                            |
+| RWEB_0048 image sizing    | `getBoundingClientRect` peut retourner 0 pour les images hors viewport — limiter aux images visibles   |
+| RWEB_0056 event listeners | CDP `getEventListeners` ne remonte pas les listeners délégués — détection uniquement des non-délégués  |
+| RWEB_0057 AST inline      | Analyse statique uniquement du JS inline — le JS externe non servi en source map n'est pas couvert     |
+| Seuils RWEB               | Certains `maxValue` des fiches MCP sont à valider au cas par cas — préférer la lecture via MCP greenit |
+| Volume                    | 20+ audits nouveaux — prévoir plusieurs PRs par phase plutôt qu'une seule PR massive                   |

--- a/.superpowers/specs/2026-05-28-rweb-backlog-design.md
+++ b/.superpowers/specs/2026-05-28-rweb-backlog-design.md
@@ -19,39 +19,31 @@ Ce document organise le backlog en deux parties : corrections des audits existan
 
 ## Partie 1 — Corrections des audits existants
 
-### 1.1 `rweb-css-containment` → remapping sur RWEB_0052 (P1 🔴)
+### 1.1 `rweb-css-containment` → rendre autonome, supprimer la référence RWEB_0039 (P1 🔴)
 
-**Problème** : l'audit compte les fichiers CSS chargés (`scoreDisplayMode: 'manual'`), ce qui correspond à RWEB_0052, pas à RWEB_0039 (propriété CSS `contain`).
+**Problème** : l'audit compte les fichiers CSS chargés (`scoreDisplayMode: 'manual'`), ce qui ne correspond ni à RWEB_0039 (propriété CSS `contain`) ni à RWEB_0052 (réduction repaint/reflow). Forcer un remapping serait trompeur.
 
-**Actions** :
+**Décision** : rendre l'audit autonome et informatif — supprimer le préfixe RWEB_0039 du titre, mettre à jour la description pour refléter ce qu'il détecte réellement (nombre de fichiers CSS chargés). L'`id` et l'entrée dans `plugin.ts` restent inchangés.
 
-- Option A — Remapper l'audit sur `RWEB_0052`, mettre à jour `id`, `title`, l'entrée dans `plugin.ts` et `refs-urls.ts`
-- Option B — Implémenter la vraie détection RWEB_0039 : vérifier via CDP ou `getComputedStyle` que les éléments clés du DOM utilisent la propriété `contain`
-
-**Recommandation** : Option A (Option B nécessite un gatherer CDP dédié). Créer ensuite un vrai audit `rweb-css-containment` (RWEB_0039) séparément.
+> ⚠️ RWEB_0052 (repaint/reflow) a été évalué comme candidat mais rejeté : comptage de fichiers CSS ≠ réduction de repaint. Un vrai audit RWEB_0039 (propriété `contain`) nécessiterait un gatherer CDP dédié — à traiter en Phase 3+.
 
 **Fichiers** :
 
-- `audits/bp/rweb-css-containment.ts` — mise à jour `id` et `title`
-- `plugin.ts` — mise à jour `auditRefs`
-- `locales/fr.json` — mise à jour clés
+- `audits/bp/rweb-css-containment.ts` — mise à jour `title` et `description` uniquement
+- `locales/fr.json` — mise à jour clés FR
 
 ---
 
-### 1.2 `rweb-no-document-write` → corriger le mapping RWEB (P1 🔴)
+### 1.2 `rweb-no-document-write` → rendre autonome, supprimer la référence RWEB_0044 (P1 🔴)
 
-**Problème** : l'audit détecte l'usage de l'API `doc-write` dans les scripts inline. Or RWEB_0044 concerne les modifications DOM pendant une traversée d'arbre (boucle sur `childNodes`), ce qui est différent.
+**Problème** : l'audit détecte l'usage de l'API `doc-write` dans les scripts inline. Or RWEB_0044 concerne les modifications DOM pendant une traversée d'arbre (boucle sur `childNodes`) — concept distinct. RWEB_0057 (réduire les accès DOM via JS) a été évalué comme candidat mais couvre un périmètre plus large que le seul pattern `document.write`.
 
-**Actions** :
-
-- Identifier la fiche RWEB correcte pour cette API (candidat : RWEB_0057 — réduire les accès DOM via JS)
-- Mettre à jour `title`, `description`, l'ID RWEB référencé, et `refs-urls.ts`
+**Décision** : rendre l'audit autonome — supprimer le préfixe RWEB_0044, mettre à jour `title` et `description` pour décrire précisément ce qui est détecté. L'`id` et l'entrée dans `plugin.ts` restent inchangés.
 
 **Fichiers** :
 
-- `audits/bp/rweb-no-document-write.ts`
-- `plugin.ts`
-- `locales/fr.json`
+- `audits/bp/rweb-no-document-write.ts` — mise à jour `title` et `description`
+- `locales/fr.json` — mise à jour clés FR
 
 ---
 
@@ -282,38 +274,38 @@ Triés par score impact × priorité. Chaque audit suit le pattern standard : fi
 
 ## Fichiers à créer / modifier
 
-| Fichier                                 | Action                                       |
-| --------------------------------------- | -------------------------------------------- |
-| `audits/bp/rweb-css-containment.ts`     | Remapping RWEB_0052 (correction P1 🔴)       |
-| `audits/bp/rweb-no-document-write.ts`   | Correction mapping RWEB_0044 (P1 🔴)         |
-| `audits/bp/rweb-combine-assets.ts`      | Alignement seuils maxValue=2 (P1 🔴)         |
-| `audits/bp/rweb-no-unused-code.ts`      | Correction mapping RWEB_0046 (P1 🔴)         |
-| `audits/bp/rweb-no-js-errors.ts`        | Correction mapping RWEB_0043 (P1 🔴)         |
-| `audits/bp/rweb-minification.ts`        | Extension NetworkRecords (P2 🟡)             |
-| `audits/bp/rweb-cache-control.ts`       | Vérification max-age + Expires (P2 🟡)       |
-| `audits/bp/rweb-no-hidden-images.ts`    | Extension visibility/opacity (P3 🟡)         |
-| `audits/bp/rweb-lazy-loading.ts`        | Restreindre aux images below-fold (P2 🟡)    |
-| `audits/bp/rweb-no-animations.ts`       | Aligner seuil maxValue=2 (P2 🟡)             |
-| `audits/bp/rweb-no-autoplay.ts`         | Ajouter vérif preload="none" (P2 🟡)         |
-| `audits/bp/rweb-no-cookie-on-static.ts` | Passer au comptage par domaine (P2 🟡)       |
-| `gatherers/bp-gatherer.ts`              | Extension autoplayDetails (P2 🟡)            |
-| `audits/bp/rweb-library-coverage.ts`    | Nouveau — RWEB_0015                          |
-| `audits/bp/rweb-image-sizing.ts`        | Nouveau — RWEB_0048                          |
-| `audits/bp/rweb-optimize-images.ts`     | Nouveau — RWEB_0049                          |
-| `audits/bp/rweb-prefer-glyphs.ts`       | Nouveau — RWEB_0050                          |
-| `audits/bp/rweb-total-blocking-time.ts` | Nouveau — RWEB_0053 (wrapper LH natif)       |
-| `audits/bp/rweb-event-delegation.ts`    | Nouveau — RWEB_0056 (CDP)                    |
-| `audits/bp/rweb-media-transcription.ts` | Nouveau — RWEB_0030                          |
-| `audits/bp/rweb-http-requests.ts`       | Nouveau — RWEB_0047                          |
-| `audits/bp/rweb-http-cache.ts`          | Nouveau — RWEB_0074                          |
-| `audits/bp/rweb-pagination.ts`          | Nouveau — RWEB_0013 (heuristique)            |
-| `audits/bp/rweb-local-storage.ts`       | Nouveau — RWEB_0064                          |
-| `audits/bp/rweb-bfcache.ts`             | Nouveau — RWEB_0008 (wrapper LH natif)       |
-| `audits/bp/rweb-api-cache.ts`           | Nouveau — RWEB_0021                          |
-| `audits/bp/rweb-dom-access.ts`          | Nouveau — RWEB_0057 (AST inline)             |
-| `plugin.ts`                             | Enregistrement de tous les nouveaux audits   |
-| `locales/fr.json`                       | Traductions FR pour tous les nouveaux audits |
-| `refs-urls.ts`                          | Ajout des nouveaux IDs RWEB                  |
+| Fichier                                 | Action                                            |
+| --------------------------------------- | ------------------------------------------------- |
+| `audits/bp/rweb-css-containment.ts`     | Rendre autonome — supprimer ref RWEB_0039 (P1 🔴) |
+| `audits/bp/rweb-no-document-write.ts`   | Rendre autonome — supprimer ref RWEB_0044 (P1 🔴) |
+| `audits/bp/rweb-combine-assets.ts`      | Alignement seuils maxValue=2 (P1 🔴)              |
+| `audits/bp/rweb-no-unused-code.ts`      | Correction mapping RWEB_0046 (P1 🔴)              |
+| `audits/bp/rweb-no-js-errors.ts`        | Correction mapping RWEB_0043 (P1 🔴)              |
+| `audits/bp/rweb-minification.ts`        | Extension NetworkRecords (P2 🟡)                  |
+| `audits/bp/rweb-cache-control.ts`       | Vérification max-age + Expires (P2 🟡)            |
+| `audits/bp/rweb-no-hidden-images.ts`    | Extension visibility/opacity (P3 🟡)              |
+| `audits/bp/rweb-lazy-loading.ts`        | Restreindre aux images below-fold (P2 🟡)         |
+| `audits/bp/rweb-no-animations.ts`       | Aligner seuil maxValue=2 (P2 🟡)                  |
+| `audits/bp/rweb-no-autoplay.ts`         | Ajouter vérif preload="none" (P2 🟡)              |
+| `audits/bp/rweb-no-cookie-on-static.ts` | Passer au comptage par domaine (P2 🟡)            |
+| `gatherers/bp-gatherer.ts`              | Extension autoplayDetails (P2 🟡)                 |
+| `audits/bp/rweb-library-coverage.ts`    | Nouveau — RWEB_0015                               |
+| `audits/bp/rweb-image-sizing.ts`        | Nouveau — RWEB_0048                               |
+| `audits/bp/rweb-optimize-images.ts`     | Nouveau — RWEB_0049                               |
+| `audits/bp/rweb-prefer-glyphs.ts`       | Nouveau — RWEB_0050                               |
+| `audits/bp/rweb-total-blocking-time.ts` | Nouveau — RWEB_0053 (wrapper LH natif)            |
+| `audits/bp/rweb-event-delegation.ts`    | Nouveau — RWEB_0056 (CDP)                         |
+| `audits/bp/rweb-media-transcription.ts` | Nouveau — RWEB_0030                               |
+| `audits/bp/rweb-http-requests.ts`       | Nouveau — RWEB_0047                               |
+| `audits/bp/rweb-http-cache.ts`          | Nouveau — RWEB_0074                               |
+| `audits/bp/rweb-pagination.ts`          | Nouveau — RWEB_0013 (heuristique)                 |
+| `audits/bp/rweb-local-storage.ts`       | Nouveau — RWEB_0064                               |
+| `audits/bp/rweb-bfcache.ts`             | Nouveau — RWEB_0008 (wrapper LH natif)            |
+| `audits/bp/rweb-api-cache.ts`           | Nouveau — RWEB_0021                               |
+| `audits/bp/rweb-dom-access.ts`          | Nouveau — RWEB_0057 (AST inline)                  |
+| `plugin.ts`                             | Enregistrement de tous les nouveaux audits        |
+| `locales/fr.json`                       | Traductions FR pour tous les nouveaux audits      |
+| `refs-urls.ts`                          | Ajout des nouveaux IDs RWEB                       |
 
 ---
 

--- a/docs/superpowers/plans/2026-05-28-rweb-corrections-phase1-critiques.md
+++ b/docs/superpowers/plans/2026-05-28-rweb-corrections-phase1-critiques.md
@@ -1,0 +1,436 @@
+# Corrections RWEB Phase 1 — Incohérences critiques
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Corriger les 5 incohérences critiques (P1 🔴) entre les audits Lighthouse et leurs fiches RWEB : un scoring erroné (Task 1) et quatre mappings de métadonnées incorrects (Tasks 2–5).
+
+**Architecture:** Chaque task est autonome. Task 1 (`rweb-combine-assets`) change le scoring — elle suit un cycle TDD complet : `expected-results.json` en premier, LHCI test vérifié FAIL, correction du code, re-vérification PASS. Tasks 2–5 sont des corrections de métadonnées (`title`/`description` uniquement) sans impact sur les scores ; le test LHCI ne doit pas régresser. Aucun changement d'`id` d'audit — `plugin.ts` et `refs-urls.ts` ne sont pas modifiés.
+
+**Tech Stack:** TypeScript · Lighthouse Audit API · ICU message format (i18n `createIcuMessageFn`) · LHCI (tests d'intégration via `pnpm test`) · `pnpm typecheck:strict` pour la vérification TypeScript cross-packages
+
+---
+
+## Structure des fichiers
+
+| Fichier                                                              | Rôle dans ce plan                         |
+| -------------------------------------------------------------------- | ----------------------------------------- |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-combine-assets.ts`    | Task 1 — correction scoring               |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-css-containment.ts`   | Task 2 — correction metadata              |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-document-write.ts` | Task 3 — correction metadata              |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-unused-code.ts`    | Task 4 — correction metadata              |
+| `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-js-errors.ts`      | Task 5 — correction metadata              |
+| `libs/ecoindex-lh-plugin-ts/src/locales/fr.json`                     | Traductions FR — modifié dans chaque task |
+| `test/test-pages/expected-results.json`                              | Task 1 uniquement — score `1` → `0`       |
+
+---
+
+## Task 1 : `rweb-combine-assets` — Aligner le scoring sur RWEB_0078 (maxValue=2)
+
+**Problème :** le scoring tolère ≤ 10 fichiers (score=1), ≤ 15 (score=0.5), sinon 0. La fiche RWEB_0078 indique `maxValue: 2`. La page de test (`bp-violations.html`) charge 8 fichiers CSS, ce qui retourne score=1 alors que RWEB_0078 exige score=0.
+
+**Files :**
+
+- Modify: `test/test-pages/expected-results.json`
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-combine-assets.ts`
+- Modify: `libs/ecoindex-lh-plugin-ts/src/locales/fr.json`
+
+- [ ] **Step 1 : Mettre à jour le test attendu (TDD — le test doit d'abord échouer)**
+
+Dans `test/test-pages/expected-results.json`, section `"bp-violations" > "expectedBPAudits"`, remplacer :
+
+```json
+"rweb-combine-assets": 1,
+```
+
+par :
+
+```json
+"rweb-combine-assets": 0,
+```
+
+- [ ] **Step 2 : Vérifier que le test échoue (le code n'est pas encore corrigé)**
+
+```bash
+pnpm test
+```
+
+Attendu : FAIL — le test signale que `rweb-combine-assets` retourne `1` mais que la valeur attendue est `0`. Les autres audits doivent continuer à passer.
+
+- [ ] **Step 3 : Corriger le scoring et le titre dans l'audit**
+
+Dans `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-combine-assets.ts`, remplacer le bloc `UIStrings` (lignes 6–14) :
+
+```typescript
+const UIStrings = {
+  title: 'RWEB_0078 - Combine CSS and JS files (≤2 each)',
+  failureTitle: 'RWEB_0078 - Too many separate CSS/JS files',
+  description:
+    'Concatenate CSS and JS files to reduce HTTP requests. [See RWEB_0078](https://rweb.greenit.fr/en/fiches/RWEB_0078-combining-css-and-javascript-files)',
+  displayValue: '{cssCount} CSS + {jsCount} JS files',
+  colLabelUrl: 'URL',
+  colLabelType: 'Type',
+}
+```
+
+Puis remplacer la logique de scoring — les lignes `let score: number … }` (lignes 43–50) — par :
+
+```typescript
+const max = Math.max(cssCount, jsCount)
+const score = max <= 2 ? 1 : 0
+```
+
+- [ ] **Step 4 : Mettre à jour la traduction française**
+
+Dans `libs/ecoindex-lh-plugin-ts/src/locales/fr.json`, remplacer la clé `title` de cet audit (ligne 53–55) :
+
+```json
+  "audits/bp/rweb-combine-assets.js | title": {
+    "message": "RWEB_0078 - Combiner les fichiers CSS et JS (≤2 chacun)"
+  },
+```
+
+- [ ] **Step 5 : Typecheck**
+
+```bash
+pnpm typecheck:strict
+```
+
+Attendu : aucune erreur TypeScript.
+
+- [ ] **Step 6 : Vérifier que le test passe**
+
+```bash
+pnpm test
+```
+
+Attendu : PASS — `rweb-combine-assets: 0` est cohérent avec `expected-results.json`. Les autres scores restent inchangés.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add test/test-pages/expected-results.json \
+  libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-combine-assets.ts \
+  libs/ecoindex-lh-plugin-ts/src/locales/fr.json
+git commit -m "fix(audit): align rweb-combine-assets scoring with RWEB_0078 maxValue=2"
+```
+
+---
+
+## Task 2 : `rweb-css-containment` — Retirer la référence trompeuse RWEB_0039
+
+**Problème :** l'audit compte les fichiers CSS chargés via `NetworkRecords` et retourne `score: null` (`scoreDisplayMode: 'manual'`). Son titre revendique RWEB_0039 (propriété CSS `contain`) qu'il ne vérifie pas — la propriété `contain` nécessite un gatherer CDP dédié, non disponible ici. L'audit est conservé comme vérification informative manuelle ; son `id` reste `rweb-css-containment` (pas de changement dans `plugin.ts`).
+
+**Files :**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-css-containment.ts`
+- Modify: `libs/ecoindex-lh-plugin-ts/src/locales/fr.json`
+
+- [ ] **Step 1 : Corriger UIStrings dans l'audit**
+
+Dans `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-css-containment.ts`, remplacer le bloc `UIStrings` (lignes 6–13) :
+
+```typescript
+const UIStrings = {
+  title: 'CSS files loaded — manual containment review',
+  failureTitle: 'CSS containment requires manual review',
+  description:
+    'This audit counts CSS files loaded. It cannot automatically verify the CSS `contain` property (RWEB_0039 requires CDP introspection). Review your stylesheets manually to ensure key layout elements use `contain: layout` or `contain: paint`.',
+  displayValue:
+    "{count} CSS file(s) loaded — verify 'contain' property usage manually.",
+}
+```
+
+- [ ] **Step 2 : Mettre à jour les traductions françaises**
+
+Dans `libs/ecoindex-lh-plugin-ts/src/locales/fr.json`, remplacer les 4 clés de cet audit (lignes 77–88) :
+
+```json
+  "audits/bp/rweb-css-containment.js | description": {
+    "message": "Cet audit compte les fichiers CSS chargés. Il ne peut pas vérifier automatiquement la propriété CSS `contain` (RWEB_0039 nécessite une inspection CDP). Vérifiez manuellement que les éléments de mise en page principaux utilisent `contain: layout` ou `contain: paint`."
+  },
+  "audits/bp/rweb-css-containment.js | displayValue": {
+    "message": "{count} fichier(s) CSS chargé(s) — vérifiez l'utilisation de la propriété 'contain' manuellement."
+  },
+  "audits/bp/rweb-css-containment.js | failureTitle": {
+    "message": "Le confinement CSS nécessite une vérification manuelle"
+  },
+  "audits/bp/rweb-css-containment.js | title": {
+    "message": "Fichiers CSS chargés — vérification manuelle du confinement"
+  },
+```
+
+- [ ] **Step 3 : Typecheck**
+
+```bash
+pnpm typecheck:strict
+```
+
+Attendu : aucune erreur TypeScript.
+
+- [ ] **Step 4 : Vérifier pas de régression**
+
+```bash
+pnpm test
+```
+
+Attendu : PASS — `rweb-css-containment: null` inchangé dans `expected-results.json`.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-css-containment.ts \
+  libs/ecoindex-lh-plugin-ts/src/locales/fr.json
+git commit -m "fix(audit): remove misleading RWEB_0039 claim from rweb-css-containment"
+```
+
+---
+
+## Task 3 : `rweb-no-document-write` — Corriger le mapping RWEB_0044
+
+**Problème :** l'audit détecte l'usage de l'API `doc-write` dans les scripts inline via regex. RWEB_0044 concerne les modifications DOM pendant une traversée d'arbre (`for` sur `childNodes`) — deux patterns JavaScript distincts. Le comportement de l'audit est correct ; seules les métadonnées sont erronées.
+
+Note : l'audit utilise `BLOCKING_WRITE_RE` pour détecter `document['write'](` et l'équivalent avec notation pointée. Cette logique est conservée sans changement.
+
+**Files :**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-document-write.ts`
+- Modify: `libs/ecoindex-lh-plugin-ts/src/locales/fr.json`
+
+- [ ] **Step 1 : Corriger UIStrings dans l'audit**
+
+Dans `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-document-write.ts`, remplacer le bloc `UIStrings` (lignes 19–27) :
+
+```typescript
+const UIStrings = {
+  title: 'Avoid blocking DOM write API in inline scripts',
+  failureTitle: 'Blocking DOM write API detected in inline scripts',
+  description:
+    'Using the deprecated DOM write API blocks HTML parsing and forces a full browser re-parse. Replace it with modern DOM manipulation methods (e.g. element.insertAdjacentHTML or appendChild).',
+  displayValuePass: 'No blocking DOM write API detected',
+  displayValueFail: '{count} blocking DOM write API call(s) in inline scripts',
+  colLabelScriptSnippet: 'Script snippet',
+}
+```
+
+- [ ] **Step 2 : Mettre à jour les traductions françaises**
+
+Dans `libs/ecoindex-lh-plugin-ts/src/locales/fr.json`, remplacer les 6 clés de cet audit (lignes 326–343) :
+
+```json
+  "audits/bp/rweb-no-document-write.js | colLabelScriptSnippet": {
+    "message": "Extrait de script"
+  },
+  "audits/bp/rweb-no-document-write.js | description": {
+    "message": "L'utilisation de l'API DOM d'écriture dépréciée bloque l'analyse HTML et force un re-parsing complet. Remplacez-la par des méthodes modernes (ex: element.insertAdjacentHTML ou appendChild)."
+  },
+  "audits/bp/rweb-no-document-write.js | displayValueFail": {
+    "message": "{count} appel(s) à l'API d'écriture DOM dans les scripts inline"
+  },
+  "audits/bp/rweb-no-document-write.js | displayValuePass": {
+    "message": "Aucun appel à l'API d'écriture DOM détecté"
+  },
+  "audits/bp/rweb-no-document-write.js | failureTitle": {
+    "message": "API d'écriture DOM bloquante détectée dans les scripts inline"
+  },
+  "audits/bp/rweb-no-document-write.js | title": {
+    "message": "Éviter l'API d'écriture DOM dans les scripts inline"
+  },
+```
+
+- [ ] **Step 3 : Typecheck**
+
+```bash
+pnpm typecheck:strict
+```
+
+Attendu : aucune erreur TypeScript.
+
+- [ ] **Step 4 : Vérifier pas de régression**
+
+```bash
+pnpm test
+```
+
+Attendu : PASS — `rweb-no-document-write: 0` inchangé dans `expected-results.json`.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-document-write.ts \
+  libs/ecoindex-lh-plugin-ts/src/locales/fr.json
+git commit -m "fix(audit): remove misleading RWEB_0044 mapping from rweb-no-document-write"
+```
+
+---
+
+## Task 4 : `rweb-no-unused-code` — Corriger le mapping RWEB_0046
+
+**Problème :** l'audit détecte les `<script src="...">` sans `async` ou `defer` (scripts bloquants). RWEB_0046 est "charger du code uniquement quand nécessaire" (chargement différé) — concept distinct du mode de chargement synchrone vs. async. Aucune fiche RWEB ne couvre exactement les render-blocking scripts ; l'audit devient autonome.
+
+**Files :**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-unused-code.ts`
+- Modify: `libs/ecoindex-lh-plugin-ts/src/locales/fr.json`
+
+- [ ] **Step 1 : Corriger UIStrings dans l'audit**
+
+Dans `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-unused-code.ts`, remplacer le bloc `UIStrings` (lignes 15–23) :
+
+```typescript
+const UIStrings = {
+  title: 'Avoid render-blocking external scripts',
+  failureTitle: 'Render-blocking external scripts detected',
+  description:
+    'Add async or defer to external scripts to prevent blocking the critical rendering path. Render-blocking scripts delay page display and increase CPU usage unnecessarily.',
+  displayValuePass: 'No render-blocking external scripts',
+  displayValueFail: '{count} render-blocking external script(s)',
+  colLabelScriptUrl: 'Script URL',
+}
+```
+
+- [ ] **Step 2 : Mettre à jour les traductions françaises**
+
+Dans `libs/ecoindex-lh-plugin-ts/src/locales/fr.json`, remplacer les 6 clés de cet audit (lignes 488–505) :
+
+```json
+  "audits/bp/rweb-no-unused-code.js | colLabelScriptUrl": {
+    "message": "URL du script"
+  },
+  "audits/bp/rweb-no-unused-code.js | description": {
+    "message": "Ajoutez async ou defer aux scripts externes pour éviter de bloquer le chemin de rendu critique. Les scripts bloquants retardent l'affichage de la page et augmentent inutilement la consommation CPU."
+  },
+  "audits/bp/rweb-no-unused-code.js | displayValueFail": {
+    "message": "{count} script(s) externe(s) bloquant(s) le rendu"
+  },
+  "audits/bp/rweb-no-unused-code.js | displayValuePass": {
+    "message": "Aucun script externe bloquant le rendu"
+  },
+  "audits/bp/rweb-no-unused-code.js | failureTitle": {
+    "message": "Scripts externes bloquants le rendu détectés"
+  },
+  "audits/bp/rweb-no-unused-code.js | title": {
+    "message": "Éviter les scripts externes bloquants le rendu"
+  },
+```
+
+- [ ] **Step 3 : Typecheck**
+
+```bash
+pnpm typecheck:strict
+```
+
+Attendu : aucune erreur TypeScript.
+
+- [ ] **Step 4 : Vérifier pas de régression**
+
+```bash
+pnpm test
+```
+
+Attendu : PASS — `rweb-no-unused-code: 0` inchangé dans `expected-results.json`.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-unused-code.ts \
+  libs/ecoindex-lh-plugin-ts/src/locales/fr.json
+git commit -m "fix(audit): remove misleading RWEB_0046 mapping from rweb-no-unused-code"
+```
+
+---
+
+## Task 5 : `rweb-no-js-errors` — Corriger le mapping RWEB_0043
+
+**Problème :** l'audit filtre les `ConsoleMessages` de niveau `error` (erreurs JavaScript runtime — `console.error()` enregistrés pendant le chargement). RWEB_0043 concerne la validation statique par un linter ESLint (`maxValue: 0` lignes en erreur) — non détectable par Lighthouse. Les titres revendiquent à tort une association avec un linter.
+
+**Files :**
+
+- Modify: `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-js-errors.ts`
+- Modify: `libs/ecoindex-lh-plugin-ts/src/locales/fr.json`
+
+- [ ] **Step 1 : Corriger UIStrings dans l'audit**
+
+Dans `libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-js-errors.ts`, remplacer le bloc `UIStrings` (lignes 11–19) :
+
+```typescript
+const UIStrings = {
+  title: 'No JavaScript runtime errors in console',
+  failureTitle: 'JavaScript runtime errors detected in console',
+  description:
+    'Fix JavaScript errors detected at runtime. These are console.error() calls recorded during page load and indicate broken features. Unlike static linting (RWEB_0043), this check does not cover code style or syntax issues.',
+  displayValuePass: 'No JavaScript runtime errors',
+  displayValueFail: '{count} JavaScript runtime error(s)',
+  colLabelErrorMessage: 'Error message',
+}
+```
+
+- [ ] **Step 2 : Mettre à jour les traductions françaises**
+
+Dans `libs/ecoindex-lh-plugin-ts/src/locales/fr.json`, remplacer les 6 clés de cet audit (lignes 428–445) :
+
+```json
+  "audits/bp/rweb-no-js-errors.js | colLabelErrorMessage": {
+    "message": "Message d'erreur"
+  },
+  "audits/bp/rweb-no-js-errors.js | description": {
+    "message": "Corrigez les erreurs JavaScript détectées à l'exécution. Il s'agit d'appels console.error() enregistrés pendant le chargement de la page. Contrairement à un linter statique (RWEB_0043), ce contrôle ne couvre pas les problèmes de style ou de syntaxe."
+  },
+  "audits/bp/rweb-no-js-errors.js | displayValueFail": {
+    "message": "{count} erreur(s) JavaScript runtime"
+  },
+  "audits/bp/rweb-no-js-errors.js | displayValuePass": {
+    "message": "Aucune erreur JavaScript runtime"
+  },
+  "audits/bp/rweb-no-js-errors.js | failureTitle": {
+    "message": "Erreurs JavaScript runtime détectées dans la console"
+  },
+  "audits/bp/rweb-no-js-errors.js | title": {
+    "message": "Pas d'erreurs JavaScript runtime dans la console"
+  },
+```
+
+- [ ] **Step 3 : Typecheck**
+
+```bash
+pnpm typecheck:strict
+```
+
+Attendu : aucune erreur TypeScript.
+
+- [ ] **Step 4 : Vérifier pas de régression**
+
+```bash
+pnpm test
+```
+
+Attendu : PASS — `rweb-no-js-errors: 0` inchangé dans `expected-results.json`.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-no-js-errors.ts \
+  libs/ecoindex-lh-plugin-ts/src/locales/fr.json
+git commit -m "fix(audit): remove misleading RWEB_0043 mapping from rweb-no-js-errors"
+```
+
+---
+
+## Auto-vérification du plan
+
+### Couverture spec (PRD `.superpowers/specs/2026-05-28-rweb-backlog-design.md`)
+
+| Section PRD                                           | Task   | Statut |
+| ----------------------------------------------------- | ------ | ------ |
+| 1.1 `rweb-css-containment` → retirer RWEB_0039        | Task 2 | ✅     |
+| 1.2 `rweb-no-document-write` → corriger RWEB_0044     | Task 3 | ✅     |
+| 1.3 `rweb-combine-assets` → aligner seuils maxValue=2 | Task 1 | ✅     |
+| 1.7 `rweb-no-unused-code` → corriger RWEB_0046        | Task 4 | ✅     |
+| 1.8 `rweb-no-js-errors` → corriger RWEB_0043          | Task 5 | ✅     |
+
+### Décisions et compromis
+
+- **`rweb-css-containment` — id conservé** : le PRD suggérait de remapper sur RWEB_0052 (repaint/reflow), mais RWEB_0052 ne correspond pas non plus au comptage de fichiers CSS. Changer l'id casserait `expected-results.json` et `plugin.ts`. Décision : titre/description honnêtes, audit reste informationnel manuel.
+- **`rweb-no-document-write` — sans RWEB** : RWEB_0057 (réduire accès DOM) était candidat mais trop éloigné du comportement concret (API dépréciée de parsing). L'audit est rendu autonome.
+- **`rweb-no-unused-code` — sans RWEB** : aucune fiche RWEB ne couvre exactement les render-blocking scripts. L'audit est rendu autonome.
+- **`refs-urls.ts` non modifié** : aucune entrée supprimée ni ajoutée dans ce plan.
+- **`≤ 2` dans le titre** : encodé en Unicode (`≤`) dans le code pour éviter des problèmes d'encodage dans certains terminaux ; s'affiche correctement dans le rapport Lighthouse.

--- a/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-cookie-size.ts
+++ b/libs/ecoindex-lh-plugin-ts/src/audits/bp/rweb-cookie-size.ts
@@ -7,10 +7,10 @@ import { createIcuMessageFn } from 'lighthouse/core/lib/i18n/i18n.js'
 const MAX_COOKIE_BYTES = 512
 
 const UIStrings = {
-  title: 'RWEB_0062 - Cookie size ≤ 512 bytes',
-  failureTitle: 'RWEB_0062 - Cookie header exceeds 512 bytes',
+  title: 'Cookie size ≤ 512 bytes',
+  failureTitle: 'Cookie header exceeds 512 bytes',
   description:
-    'Keep Cookie request headers under 512 bytes to reduce HTTP overhead. [See RWEB_0062](https://rweb.greenit.fr/en/fiches/RWEB_0062-optimise-cookie-size)',
+    'Keep Cookie request headers under 512 bytes to reduce HTTP overhead.',
   displayValuePass: 'No Cookie header exceeds 512 bytes',
   displayValueFail: '{count} request(s) with oversized Cookie header',
   colLabelUrl: 'URL',

--- a/libs/ecoindex-lh-plugin-ts/src/locales/fr.json
+++ b/libs/ecoindex-lh-plugin-ts/src/locales/fr.json
@@ -60,7 +60,7 @@
     "message": "URL"
   },
   "audits/bp/rweb-cookie-size.js | description": {
-    "message": "Maintenez les en-têtes de requête Cookie sous 512 octets pour réduire la surcharge HTTP. [Voir RWEB_0062](https://rweb.greenit.fr/fr/fiches/RWEB_0062-optimiser-la-taille-des-cookies)"
+    "message": "Maintenez les en-têtes de requête Cookie sous 512 octets pour réduire la surcharge HTTP."
   },
   "audits/bp/rweb-cookie-size.js | displayValueFail": {
     "message": "{count} requête(s) avec en-tête Cookie surdimensionné"
@@ -69,10 +69,10 @@
     "message": "Aucun en-tête Cookie ne dépasse 512 octets"
   },
   "audits/bp/rweb-cookie-size.js | failureTitle": {
-    "message": "RWEB_0062 - L'en-tête cookie dépasse 512 octets"
+    "message": "L'en-tête Cookie dépasse 512 octets"
   },
   "audits/bp/rweb-cookie-size.js | title": {
-    "message": "RWEB_0062 - Taille des cookies ≤ 512 octets"
+    "message": "Taille des cookies ≤ 512 octets"
   },
   "audits/bp/rweb-css-containment.js | description": {
     "message": "Utilisez la propriété CSS containment pour optimiser les performances de rendu. [Voir RWEB_0039](https://rweb.greenit.fr/fr/fiches/RWEB_0039-utiliser-les-compartiments-css)"
@@ -918,4 +918,3 @@
     "message": "Taille transférée (Kio)"
   }
 }
-

--- a/todo/rapport-coherence-rweb.md
+++ b/todo/rapport-coherence-rweb.md
@@ -28,7 +28,7 @@
 
 **Écart** : l'audit mesure le _nombre de fichiers CSS_, la fiche mesure l'_usage de la propriété CSS `contain`_. Ce sont deux métriques sans rapport.
 
-**Correction recommandée** : Option A — remapper cet audit sur RWEB_0052 (qui concerne la réduction du nombre de CSS). Option B — implémenter la vraie détection de `contain` via CDP `getComputedStyle`.
+**Correction recommandée** : rendre l'audit autonome — supprimer le préfixe RWEB_0039 du titre et mettre à jour la description pour refléter ce qu'il détecte réellement (nombre de fichiers CSS chargés). RWEB_0052 (repaint/reflow) a été évalué mais rejeté : comptage de fichiers CSS ≠ réduction de repaint. Un vrai audit RWEB_0039 (propriété `contain`) nécessiterait un gatherer CDP dédié — à traiter ultérieurement.
 
 ---
 
@@ -40,7 +40,7 @@
 
 **Écart** : l'API `doc-write` est un accès bloquant au document, pas une modification pendant traversée d'arbre. Ce sont deux anti-patterns JS différents.
 
-**Correction recommandée** : identifier la fiche RWEB correcte pour cette API (candidat : RWEB_0057 — réduire les accès DOM) et corriger le mapping.
+**Correction recommandée** : rendre l'audit autonome — supprimer le préfixe RWEB_0044 du titre et mettre à jour la description pour décrire précisément ce qui est détecté (usage de l'API d'écriture DOM bloquante dans les scripts inline). RWEB_0057 (réduire les accès DOM via JS) a été évalué mais rejeté : son périmètre est plus large que le seul pattern détecté ici.
 
 ---
 

--- a/todo/rapport-coherence-rweb.md
+++ b/todo/rapport-coherence-rweb.md
@@ -1,163 +1,338 @@
-# Rapport de cohérence — Audits RWEB vs Fiches MCP GreenIT
+# Rapport de cohérence — Audits BP vs fiches RWEB
 
-> Généré le 2026-05-28 · 36 audits RWEB analysés · Référentiel MCP GreenIT
-
----
-
-## Résumé exécutif
-
-| Statut                    | Nb  | Description                                           |
-| ------------------------- | --- | ----------------------------------------------------- |
-| 🟢 Cohérent               | 7   | Implémentation alignée avec la fiche RWEB             |
-| 🟡 Partiellement cohérent | 14  | Détection partielle ou seuils approximatifs           |
-| 🔴 Incohérent             | 6   | Fiche testée ≠ fiche implémentée, ou logique inversée |
-| ⚪ Sans fiche RWEB        | 3   | Audits sans correspondance dans le référentiel        |
+**Date** : 2026-05-28  
+**Méthode** : lecture de chaque fichier source d'audit + appel MCP `obtenir_fiche_complete` pour chaque RWEB ID référencé, puis comparaison implémentation ↔ règle de validation.  
+**Périmètre** : 39 audits dans `libs/ecoindex-lh-plugin-ts/src/audits/bp/`
 
 ---
 
-## Tableau de synthèse
+## Synthèse
 
-| Fichier audit              | ID RWEB référencé | Titre fiche                             | Statut | Problème principal                                                   |
-| -------------------------- | ----------------- | --------------------------------------- | ------ | -------------------------------------------------------------------- |
-| rweb-no-document-write     | RWEB_0044         | Éviter la manipulation DOM en traversal | 🔴     | Fiche RWEB concerne les manipulations DOM, pas `document.write`      |
-| rweb-no-unused-code        | RWEB_0046         | Éviter les scripts bloquants            | 🔴     | Fiche concerne le render-blocking, audit détecte absence async/defer |
-| rweb-no-js-errors          | RWEB_0043         | Pas d'erreurs JS console                | 🟢     | Aligné                                                               |
-| rweb-css-containment       | RWEB_0039         | CSS containment                         | 🔴     | Audit compte les fichiers CSS, fiche concerne la prop `contain`      |
-| rweb-combine-assets        | RWEB_0078         | Combiner les assets                     | 🟡     | Seuils (10/15) non documentés dans la fiche                          |
-| rweb-minification          | RWEB_0077         | Minification                            | 🔴     | Audit vérifie seulement les blocs inline, pas les fichiers externes  |
-| rweb-no-animations         | RWEB_0011         | Pas d'animations non-essentielles       | 🟡     | Détection CSS uniquement, JS non couvert                             |
-| rweb-no-autoplay           | RWEB_0114         | Pas d'autoplay                          | 🟢     | Aligné                                                               |
-| rweb-no-bitmap-ui          | RWEB_0032         | Pas d'images bitmap pour l'UI           | 🟡     | Détecte `<img>` mais pas les `background-image` CSS                  |
-| rweb-no-canvas             | RWEB_0007         | Pas de canvas                           | 🟢     | Aligné                                                               |
-| rweb-no-carousel           | RWEB_0019         | Pas de carrousel                        | 🟡     | Détection heuristique (classe CSS), non exhaustif                    |
-| rweb-no-cookie-on-static   | RWEB_0071         | Pas de cookies sur ressources statiques | 🟡     | Vérifie les headers réseau mais pas le domaine                       |
-| rweb-no-embedded-docs      | RWEB_0034         | Pas de docs embarqués                   | 🟢     | Aligné                                                               |
-| rweb-no-gif                | RWEB_0030         | Pas de GIF animés                       | 🟢     | Aligné                                                               |
-| rweb-no-hidden-images      | RWEB_0020         | Pas d'images cachées                    | 🟡     | CSS `display:none` détecté, `visibility:hidden` non                  |
-| rweb-no-inline-assets      | RWEB_0100         | Pas d'assets inline                     | 🟡     | Seuil de taille non documenté                                        |
-| rweb-no-plugins            | RWEB_0002         | Pas de plugins                          | 🟢     | Aligné                                                               |
-| rweb-no-redirects          | RWEB_0061         | Pas de redirections                     | 🟡     | Redirections chaînées non comptées                                   |
-| rweb-no-social-sdk         | RWEB_0086         | Pas de SDK sociaux                      | 🟡     | Liste de domaines à maintenir manuellement                           |
-| rweb-cache-control         | RWEB_0066         | Cache-Control                           | 🟡     | Vérifie la présence du header, pas la valeur                         |
-| rweb-cookie-size           | RWEB_0067         | Taille des cookies                      | 🟡     | Seuil (512 octets) à confirmer dans la fiche                         |
-| rweb-css-splitting         | RWEB_0053         | CSS splitting                           | 🟡     | Compte les fichiers mais pas leur taille relative                    |
-| rweb-hsts                  | RWEB_0063         | HSTS                                    | 🟢     | Aligné                                                               |
-| rweb-http-compression      | RWEB_0072         | Compression HTTP                        | 🟡     | Vérifie Content-Encoding mais pas le taux                            |
-| rweb-lazy-loading          | RWEB_0021         | Lazy loading                            | 🟡     | `loading="lazy"` HTML uniquement, JS lazy non couvert                |
-| rweb-limit-analytics       | RWEB_0087         | Limiter les analytics                   | 🟡     | Liste de domaines à maintenir manuellement                           |
-| rweb-limit-css-files       | RWEB_0052         | Limiter les fichiers CSS                | 🟢     | Aligné                                                               |
-| rweb-limit-domains         | RWEB_0079         | Limiter les domaines                    | 🟡     | Seuils à confirmer                                                   |
-| rweb-limit-fonts           | RWEB_0075         | Limiter les polices                     | 🟡     | Compte les fichiers font, pas les font-face déclarées                |
-| rweb-no-http-errors        | RWEB_0059         | Pas d'erreurs HTTP                      | 🟡     | 4xx/5xx détectés, redirections (3xx) non comptées comme erreur       |
-| rweb-optimize-svg          | RWEB_0097         | Optimiser les SVG                       | 🟡     | Taille seulement, contenu SVG non inspecté                           |
-| rweb-prefer-css            | RWEB_0010         | Préférer CSS                            | 🔴     | Fiche concerne les effets CSS vs JS, audit détecte autre chose       |
-| rweb-print-css             | RWEB_0099         | CSS d'impression                        | 🟡     | Présence de `@media print`, pas la pertinence du contenu             |
-| rweb-service-worker        | RWEB_0062         | Service Worker                          | 🟢     | Aligné                                                               |
-| rweb-uses-http2            | RWEB_0064         | Utiliser HTTP/2                         | 🟢     | Aligné                                                               |
-| rweb-no-unused-css (alias) | —                 | —                                       | ⚪     | Pas de fiche RWEB directe                                            |
-| no-carousel (sans rweb-)   | —                 | —                                       | ⚪     | Doubloon avec rweb-no-carousel                                       |
-| ecoindex-\* (4 audits)     | —                 | —                                       | ⚪     | Audits Ecoindex propres, hors référentiel RWEB                       |
+| Statut                                                                   | Nb     |
+| ------------------------------------------------------------------------ | ------ |
+| 🔴 Incohérence critique (logique ou mapping erroné)                      | 5      |
+| 🟡 Partiel (concept correct, implémentation incomplète ou seuil déviant) | 17     |
+| ✅ Aligné                                                                | 10     |
+| ➖ Sans référence RWEB (BP autonome)                                     | 7      |
+| **Total**                                                                | **39** |
 
 ---
 
-## Incohérences critiques 🔴
+## 🔴 Incohérences critiques
 
-### 1. `rweb-no-document-write` — ID RWEB_0044
+### 1. `rweb-css-containment.ts` → RWEB_0039
 
-**Ce que fait l'audit :** détecte la présence de `document.write` dans les scripts inline du HTML.
+**Ce que fait l'audit** : compte les fichiers CSS chargés via NetworkRecords (`scoreDisplayMode: 'manual'`). Le `displayValue` indique de vérifier manuellement l'usage de `contain`.
 
-**Ce que dit la fiche RWEB_0044 :** "Éviter la manipulation du DOM lors de la traversée" — concerne les modifications DOM pendant un parcours d'arbre (ex. boucle sur `childNodes`), pas l'usage de `document.write`.
+**Ce que dit la fiche** : RWEB_0039 = éléments DOM non isolés via la propriété CSS `contain`. `maxValue = 20%` d'éléments sans `contain`.
 
-**Recommandation :** Soit mapper cet audit sur la fiche RWEB correcte pour l'usage de `document.write`, soit corriger le titre pour refléter RWEB_0044.
+**Écart** : l'audit mesure le _nombre de fichiers CSS_, la fiche mesure l'_usage de la propriété CSS `contain`_. Ce sont deux métriques sans rapport.
 
----
-
-### 2. `rweb-no-unused-code` — ID RWEB_0046
-
-**Ce que fait l'audit :** détecte les balises `<script src>` sans attribut `async` ou `defer`.
-
-**Ce que dit la fiche RWEB_0046 :** "Éviter les scripts externes bloquant le rendu" — c'est cohérent en intention mais la fiche valide via la couverture de code (code mort), pas via les attributs de chargement.
-
-**Recommandation :** Renommer l'audit en `rweb-no-render-blocking-scripts` et créer un audit séparé pour le code mort (unused coverage).
+**Correction recommandée** : Option A — remapper cet audit sur RWEB_0052 (qui concerne la réduction du nombre de CSS). Option B — implémenter la vraie détection de `contain` via CDP `getComputedStyle`.
 
 ---
 
-### 3. `rweb-css-containment` — ID RWEB_0039
+### 2. `rweb-no-document-write.ts` → RWEB_0044
 
-**Ce que fait l'audit :** compte le nombre de fichiers CSS chargés (`scoreDisplayMode: 'manual'`).
+**Ce que fait l'audit** : regex sur les scripts inline pour détecter l'appel à l'API `doc-write` (via `BLOCKING_WRITE_RE`).
 
-**Ce que dit la fiche RWEB_0039 :** concerne la propriété CSS `contain` (layout/style/paint) pour limiter les recalculs de style.
+**Ce que dit la fiche** : RWEB_0044 = modifications DOM pendant une traversée de l'arbre DOM (boucle sur `childNodes`). `maxValue = 0` insertions pendant traversée.
 
-**Recommandation :** Cet audit teste en réalité RWEB_0052 (limiter les fichiers CSS). Il faut soit le re-mapper sur RWEB_0052, soit implémenter la vraie détection de la propriété `contain`.
+**Écart** : l'API `doc-write` est un accès bloquant au document, pas une modification pendant traversée d'arbre. Ce sont deux anti-patterns JS différents.
 
----
-
-### 4. `rweb-minification` — ID RWEB_0077
-
-**Ce que fait l'audit :** vérifie la minification des blocs `<style>` et `<script>` inline uniquement.
-
-**Ce que dit la fiche RWEB_0077 :** couvre la minification de tous les assets (CSS et JS), y compris les fichiers externes.
-
-**Recommandation :** Étendre l'audit aux ressources réseau (NetworkRecords) pour vérifier la minification des fichiers CSS/JS externes via leur Content-Encoding ou leur ratio taille/contenu.
+**Correction recommandée** : identifier la fiche RWEB correcte pour cette API (candidat : RWEB_0057 — réduire les accès DOM) et corriger le mapping.
 
 ---
 
-### 5. `rweb-prefer-css` — ID RWEB_0010
+### 3. `rweb-combine-assets.ts` → RWEB_0078
 
-**Ce que fait l'audit :** détecte certains patterns JS qui pourraient être remplacés par CSS.
+**Ce que fait l'audit** : score 1 si `max(nbCSS, nbJS) ≤ 10`, score 0.5 si ≤ 15, score 0 sinon.
 
-**Ce que dit la fiche RWEB_0010 :** "Préférer CSS aux scripts" — valide que les effets visuels (transitions, animations) sont en CSS plutôt qu'en JS.
+**Ce que dit la fiche** : RWEB_0078 = fichiers CSS et JS non combinés. `maxValue = 2` (combinaisons de fichiers).
 
-**Recommandation :** Revoir la logique de détection pour cibler spécifiquement les animations/transitions JS remplaçables par CSS.
+**Écart** : le seuil de l'audit (≤ 10 / ≤ 15 fichiers) est 5× à 7× supérieur au `maxValue = 2` de la fiche.
 
----
-
-### 6. `rweb-combine-assets` (seuils non documentés) — ID RWEB_0078
-
-**Ce que fait l'audit :** score 1 si ≤10 requêtes, 0.5 si ≤15, 0 si >15.
-
-**Ce que dit la fiche RWEB_0078 :** `maxValue: 2` requêtes — seuils très différents.
-
-**Recommandation :** Aligner les seuils sur la valeur de la fiche (`maxValue: 2`) ou documenter explicitement pourquoi les seuils divergent.
+**Correction recommandée** : aligner sur `maxValue = 2` ou documenter explicitement l'écart si la fiche est jugée trop contraignante pour le contexte réel.
 
 ---
 
-## Partielles notables 🟡
+### 4. `rweb-no-unused-code.ts` → RWEB_0046
 
-### `rweb-cache-control`
+**Ce que fait l'audit** : regex sur le HTML pour détecter les `<script src="...">` sans attribut `async` ou `defer` (scripts bloquants).
 
-Vérifie seulement la **présence** du header `Cache-Control`, pas sa valeur. La fiche RWEB_0066 recommande une durée minimale. L'audit devrait vérifier `max-age` > 0.
+**Ce que dit la fiche** : RWEB_0046 = ressources chargées qui ne sont pas immédiatement utilisées. `maxValue = 0` ressources chargées inutilement.
 
-### `rweb-no-hidden-images`
+**Écart** : un script bloquant (sans async/defer) n'est pas forcément inutile — il est simplement mal chargé. La fiche concerne le chargement de ressources non nécessaires, pas leur mode de chargement.
 
-Détecte `display:none` mais pas `visibility:hidden` ni `opacity:0`. Ces trois techniques cachent visuellement une image tout en la chargeant.
-
-### `rweb-lazy-loading`
-
-Ne couvre que l'attribut HTML `loading="lazy"`. Le lazy loading JS (IntersectionObserver) n'est pas détecté.
-
-### `rweb-no-social-sdk`
-
-La liste des domaines SDK sociaux est codée en dur dans l'audit. Elle doit être maintenue manuellement au fil des évolutions des plateformes.
+**Correction recommandée** : remapper l'audit sur une fiche concernant le render-blocking. Créer un audit distinct pour les ressources réellement inutilisées (Coverage API).
 
 ---
 
-## Audits sans fiche RWEB ⚪
+### 5. `rweb-no-js-errors.ts` → RWEB_0043
 
-| Audit                                                                 | Commentaire                                               |
-| --------------------------------------------------------------------- | --------------------------------------------------------- |
-| Audits `ecoindex-*` (score, grade, nodes, requests, size, water, GHG) | Propres au score Ecoindex, hors référentiel RWEB — normal |
-| `rweb-no-unused-css`                                                  | Pas de fiche RWEB identifiée — potentiellement RWEB_0046  |
+**Ce que fait l'audit** : détecte les `ConsoleMessages` de niveau `error` (erreurs runtime JS dans la console).
+
+**Ce que dit la fiche** : RWEB_0043 = lignes non validées par ESLint. `maxValue = 0` lignes en erreur ESLint (analyse statique).
+
+**Écart** : erreurs runtime console ≠ erreurs de linting statique ESLint. L'audit détecte des bugs à l'exécution, la fiche concerne la qualité statique du code.
+
+**Correction recommandée** : mapper sur une fiche de qualité runtime, ou renommer le titre pour refléter l'usage réel (détection des erreurs console JS).
 
 ---
 
-## Recommandations prioritaires
+## 🟡 Partiels
 
-| Priorité | Action                                                                             | Impact                     |
-| -------- | ---------------------------------------------------------------------------------- | -------------------------- |
-| 🔴 P1    | Corriger le mapping `rweb-css-containment` → RWEB_0052, créer vrai audit RWEB_0039 | Faux positif architectural |
-| 🔴 P1    | Corriger le mapping `rweb-no-document-write` → bonne fiche RWEB                    | Confusion référentiel      |
-| 🔴 P2    | Aligner seuils `rweb-combine-assets` sur `maxValue` de la fiche                    | Seuils arbitraires         |
-| 🟡 P2    | Étendre `rweb-minification` aux fichiers externes                                  | Couverture incomplète      |
-| 🟡 P3    | Ajouter vérification valeur `max-age` dans `rweb-cache-control`                    | Faux positifs              |
-| 🟡 P3    | Étendre `rweb-no-hidden-images` à `visibility:hidden` et `opacity:0`               | Couverture incomplète      |
+### 6. `rweb-minification.ts` → RWEB_0077
+
+**Ce que fait l'audit** : vérifie uniquement les blocs `<style>` et `<script>` inline via une heuristique `avgCharsPerLine < 80`.
+
+**Ce que dit la fiche** : RWEB_0077 = fichiers CSS, JS, HTML et SVG non minifiés. `maxValue = 0`.
+
+**Écart** : les fichiers CSS/JS/HTML/SVG externes ne sont pas vérifiés. L'audit ne couvre que l'inline.
+
+---
+
+### 7. `rweb-cache-control.ts` → RWEB_0075
+
+**Ce que fait l'audit** : vérifie la présence du header `Cache-Control` sur les ressources Document/Stylesheet/Script/Font.
+
+**Ce que dit la fiche** : RWEB_0075 = entêtes manquantes `Expires` ou `Cache-Control`. `maxValue = 0`.
+
+**Écarts** :
+
+- Le header `Expires` n'est pas vérifié
+- Un `Cache-Control: max-age=0` est un faux positif (compte comme valide)
+
+---
+
+### 8. `rweb-limit-css-files.ts` → RWEB_0035
+
+**Ce que fait l'audit** : score 1 si ≤ 7 CSS, score 0.5 si ≤ 10, score 0 si > 10.
+
+**Ce que dit la fiche** : RWEB_0035 = fichiers CSS entre 3 et 10 (range bidirectionnel : trop peu = mauvais aussi).
+
+**Écart** : l'audit ne pénalise pas si < 3 CSS (CSS non splitté). Le seuil haut (7 vs 10) est aussi plus strict que la fiche.
+
+---
+
+### 9. `rweb-no-autoplay.ts` → RWEB_0106
+
+**Ce que fait l'audit** : utilise BPGatherer `autoplayDetails` — détecte uniquement l'attribut `autoplay` sur `<video>` et `<audio>`.
+
+**Ce que dit la fiche** : RWEB_0106 = éléments video/audio sans `preload="none"` ou `autoplay`. `maxValue = 0`.
+
+**Écart** : l'audit ne vérifie pas l'absence de `preload="none"`. Un élément sans `autoplay` mais avec `preload="eager"` passe l'audit mais viole la fiche.
+
+---
+
+### 10. `rweb-http-compression.ts` → RWEB_0076
+
+**Ce que fait l'audit** : vérifie la compression (gzip/br/deflate/zstd) sur Document/Stylesheet/Script. Seuil : score 1 si ≥ 95% des ressources compressées.
+
+**Ce que dit la fiche** : RWEB_0076 = fichiers CSS, JS, HTML et SVG non compressés. `maxValue = 0`.
+
+**Écarts** :
+
+- Les SVG ne sont pas inclus dans la vérification
+- La tolérance de 5% (seuil 95%) n'est pas alignée sur `maxValue = 0`
+
+---
+
+### 11. `rweb-lazy-loading.ts` → RWEB_0051
+
+**Ce que fait l'audit** : vérifie que _toutes_ les `<img>` ont `loading="lazy"`.
+
+**Ce que dit la fiche** : RWEB_0051 = images, iframes et vidéos below the fold sans lazy loading. `maxValue = 0`.
+
+**Écart** : l'audit pénalise aussi les images above-the-fold (qui ne devraient _pas_ avoir `lazy`). La fiche concerne uniquement les éléments hors viewport initial. Les iframes et vidéos sont également ignorées.
+
+---
+
+### 12. `rweb-limit-fonts.ts` → RWEB_0032
+
+**Ce que fait l'audit** : détecte les polices chargées depuis des domaines de service connus (fonts.googleapis.com, fonts.gstatic.com, use.typekit.net…).
+
+**Ce que dit la fiche** : RWEB_0032 = polices téléchargées. `maxValue = 2`.
+
+**Écart** : les polices auto-hébergées (servies depuis le même domaine ou un CDN propre) ne sont pas détectées. Le comptage est incomplet.
+
+---
+
+### 13. `rweb-no-animations.ts` → RWEB_0009
+
+**Ce que fait l'audit** : utilise BPGatherer `animatedElementDetails`. Score 0 si _une seule_ animation est trouvée.
+
+**Ce que dit la fiche** : RWEB_0009 = animations JS/CSS par page. `maxValue = 2`.
+
+**Écart** : le seuil est 0 dans l'audit vs 2 dans la fiche (2 animations tolérées).
+
+---
+
+### 14. `rweb-no-bitmap-ui.ts` → RWEB_0038
+
+**Ce que fait l'audit** : détecte les images PNG/JPG/WebP/BMP _à l'intérieur_ des conteneurs `<header>`, `<nav>`, `<footer>`, `<button>`.
+
+**Ce que dit la fiche** : RWEB_0038 = images matricielles pour l'URL testée. `maxValue = 5`.
+
+**Écart** : l'audit restreint la détection aux conteneurs UI spécifiques. La fiche porte sur _toutes_ les images matricielles de la page, avec un seuil de 5.
+
+---
+
+### 15. `rweb-no-carousel.ts` → RWEB_0010
+
+**Ce que fait l'audit** : détecte le chargement de librairies carousel connues (swiper, slick, owl, splide, glide) dans les NetworkRecords.
+
+**Ce que dit la fiche** : RWEB_0010 = carrousels présents sur la page. `maxValue = 1`.
+
+**Écarts** :
+
+- Un carrousel codé sans librairie (vanilla JS) n'est pas détecté
+- Une librairie chargée mais non utilisée serait un faux positif
+- Le seuil de l'audit est 0 (binary) vs `maxValue = 1` de la fiche
+
+---
+
+### 16. `rweb-no-cookie-on-static.ts` → RWEB_0081
+
+**Ce que fait l'audit** : compte le nombre de _ressources_ statiques individuelles envoyées avec un header Cookie.
+
+**Ce que dit la fiche** : RWEB_0081 = domaines servant des ressources statiques avec cookie. `maxValue = 1`.
+
+**Écart** : la fiche mesure le nombre de _domaines_ concernés, l'audit mesure le nombre de _ressources_ individuelles. Un seul CDN mal configuré peut déclencher des dizaines de violations.
+
+---
+
+### 17. `rweb-limit-analytics.ts` → RWEB_0111
+
+**Ce que fait l'audit** : détecte les requêtes vers 12 domaines analytics hardcodés (Google Analytics, Matomo, Plausible, etc.). Score 1 si ≤ 1 domaine détecté.
+
+**Ce que dit la fiche** : RWEB_0111 = outils d'analytics. `maxValue = 1`.
+
+**Écart** : la liste est incomplète (Mixpanel, Amplitude, Hotjar, PostHog, Segment, etc. absents). Des outils non listés passeraient l'audit.
+
+---
+
+### 18. `rweb-optimize-svg.ts` → RWEB_0100
+
+**Ce que fait l'audit** : marque un SVG comme non optimisé si sa taille est > 2048 octets et ne contient pas de marqueur SVGO (`<!--!-->`) ou de minification évidente.
+
+**Ce que dit la fiche** : RWEB_0100 = images non optimisées. `maxValue = 0%`.
+
+**Écart** : le seuil de 2 Ko est arbitraire — un SVG complexe peut légitimement dépasser 2 Ko même optimisé. L'heuristique SVGO marker est fragile et contournable.
+
+---
+
+### 19. `rweb-no-social-sdk.ts` → RWEB_0059
+
+**Ce que fait l'audit** : filtre les requêtes vers 6 domaines SDK sociaux hardcodés (Facebook, Twitter/X, LinkedIn, Google+, Instagram).
+
+**Ce que dit la fiche** : RWEB_0059 = bibliothèques externes des réseaux sociaux. `maxValue = 0`.
+
+**Écart** : liste incomplète (TikTok, Pinterest, YouTube embed, Snapchat, etc. absents). Le concept est correct mais la couverture est partielle.
+
+---
+
+### 20. `rweb-prefer-css.ts` → RWEB_0037
+
+**Ce que fait l'audit** : regex sur le HTML pour détecter les `<img>` à l'intérieur de `<button>` et `<a>` uniquement.
+
+**Ce que dit la fiche** : RWEB_0037 = images remplaçables par CSS. `maxValue = 0`.
+
+**Écart** : la détection est très restrictive. Les images dans `<header>`, `<nav>`, les `<img>` servant d'icônes hors boutons/liens, et les `background-image` CSS non nécessaires ne sont pas couverts.
+
+---
+
+### 21. `rweb-hsts.ts` → RWEB_0084
+
+**Ce que fait l'audit** : vérifie la présence du header `Strict-Transport-Security` sur la réponse du document principal.
+
+**Ce que dit la fiche** : RWEB_0084 = non activations de HSTS (favoriser le HSTS preload). `maxValue = 0`.
+
+**Écart** : l'audit ne vérifie pas la valeur du header. Un `max-age=0` ou l'absence de `preload` passerait l'audit alors que la fiche insiste sur le HSTS preload list.
+
+---
+
+### 22. `rweb-css-splitting.ts` → RWEB_0036
+
+**Ce que fait l'audit** : détecte les fichiers CSS > 10 Ko sans attribut `media` ciblé dans leur `<link>`.
+
+**Ce que dit la fiche** : RWEB_0036 = diviser CSS. `maxValue` entre 2 et 5 bibliothèques CSS.
+
+**Écart** : l'audit vérifie le ciblage media des CSS (splitting contextuel), alors que la fiche mesure le nombre de fichiers CSS dans une plage acceptable (2 à 5). Ces deux métriques sont liées mais distinctes. Le seuil binaire (0 violations) ne reflète pas le range 2–5 de la fiche.
+
+---
+
+## ✅ Alignés
+
+| Fichier                    | RWEB ID   | Justification                                                                                                  |
+| -------------------------- | --------- | -------------------------------------------------------------------------------------------------------------- |
+| `rweb-limit-domains.ts`    | RWEB_0082 | Compte les hostnames uniques, score 1 si ≤ 5. Aligné sur maxValue = 5.                                         |
+| `rweb-no-embedded-docs.ts` | RWEB_0033 | Détecte `<embed>`, `<object>`, `<iframe src="*.pdf">`. Score 1 si 0. Aligné sur maxValue = 0.                  |
+| `rweb-no-gif.ts`           | RWEB_0099 | Détecte les .gif via NetworkRecords et HTML. Score 1 si 0. Aligné sur maxValue = 0.                            |
+| `rweb-no-inline-assets.ts` | RWEB_0042 | Compte les scripts/styles inline via BPGatherer. Score 1 si ≤ 2. Aligné sur maxValue = 2.                      |
+| `rweb-no-redirects.ts`     | RWEB_0112 | Détecte les 301/302/307/308. Score 1 si ≤ 1. Aligné sur maxValue = 1.                                          |
+| `rweb-no-canvas.ts`        | RWEB_0055 | Détecte tout `<canvas>` via BPGatherer. Score 1 si 0. Aligné sur maxValue = 0 (conservateur mais acceptable).  |
+| `rweb-print-css.ts`        | RWEB_0031 | Vérifie la présence d'un `<link rel="stylesheet" media="print">`. Score 1 si présent. Aligné sur maxValue = 1. |
+| `rweb-service-worker.ts`   | RWEB_0060 | Vérifie si un Service Worker est actif (BPGatherer.serviceWorkerActive). Score binaire. Aligné.                |
+| `rweb-title-meta.ts`       | RWEB_0011 | Vérifie `<title>` non vide ET `<meta name="description">` non vide. Score binaire. Aligné.                     |
+| `rweb-uses-http2.ts`       | RWEB_0083 | Compte les requêtes avec protocol ≠ h2/h3. Score 1 si 0. Aligné sur maxValue = 0.                              |
+
+---
+
+## ➖ Sans référence RWEB (BP autonomes)
+
+| Fichier                    | Description                                                             | Candidat RWEB                        |
+| -------------------------- | ----------------------------------------------------------------------- | ------------------------------------ |
+| `badly-sized-images.ts`    | Détecte les images affichées à une taille > 5% de leur taille naturelle | RWEB_0048 (non implémentée)          |
+| `rweb-cookie-size.ts`      | Cookie request header > 512 octets                                      | RWEB_0062 ref supprimée — à vérifier |
+| `rweb-no-hidden-images.ts` | Images avec clientRect width ou height = 0                              | RWEB_0045 (partiel)                  |
+| `rweb-no-http-errors.ts`   | Ressources avec statusCode ≥ 400                                        | Pas de fiche RWEB directe            |
+| `rweb-no-plugins.ts`       | Détecte Flash/Silverlight/Java MIME types                               | Technologie obsolète                 |
+| `thegreenwebfoundation.ts` | Vérifie si l'hébergeur est dans la base TGWF                            | RWEB_0096 (non implémentée)          |
+| `unoptimized-images.ts`    | Utilise l'artefact `OptimizedImages` (deprecated)                       | À migrer ou supprimer                |
+
+---
+
+## Tableau récapitulatif complet
+
+| Fichier                       | RWEB ID   | Statut       | Problème principal                                                      |
+| ----------------------------- | --------- | ------------ | ----------------------------------------------------------------------- |
+| `rweb-css-containment.ts`     | RWEB_0039 | 🔴 CRITIQUE  | Compte des fichiers CSS au lieu de vérifier la propriété `contain`      |
+| `rweb-no-document-write.ts`   | RWEB_0044 | 🔴 CRITIQUE  | Détecte l'API doc-write au lieu des mutations DOM pendant traversée     |
+| `rweb-combine-assets.ts`      | RWEB_0078 | 🔴 CRITIQUE  | Seuils ≤10/15 vs maxValue=2 de la fiche                                 |
+| `rweb-no-unused-code.ts`      | RWEB_0046 | 🔴 CRITIQUE  | Détecte les scripts bloquants, pas les ressources inutiles              |
+| `rweb-no-js-errors.ts`        | RWEB_0043 | 🔴 CRITIQUE  | Erreurs runtime console vs linting ESLint statique                      |
+| `rweb-minification.ts`        | RWEB_0077 | 🟡 PARTIEL   | Inline uniquement, fichiers externes ignorés                            |
+| `rweb-cache-control.ts`       | RWEB_0075 | 🟡 PARTIEL   | Pas de vérif. Expires, pas de vérif. max-age > 0                        |
+| `rweb-limit-css-files.ts`     | RWEB_0035 | 🟡 PARTIEL   | Seuil ≤7 vs plage 3–10, pas de pénalité si < 3                          |
+| `rweb-no-autoplay.ts`         | RWEB_0106 | 🟡 PARTIEL   | Manque vérif. `preload="none"`                                          |
+| `rweb-http-compression.ts`    | RWEB_0076 | 🟡 PARTIEL   | SVG exclus, tolérance 5% non alignée sur maxValue=0                     |
+| `rweb-lazy-loading.ts`        | RWEB_0051 | 🟡 PARTIEL   | Toutes les images (pas seulement below-fold), iframes/vidéos ignorées   |
+| `rweb-limit-fonts.ts`         | RWEB_0032 | 🟡 PARTIEL   | Polices auto-hébergées non détectées                                    |
+| `rweb-no-animations.ts`       | RWEB_0009 | 🟡 PARTIEL   | Seuil 0 vs maxValue=2                                                   |
+| `rweb-no-bitmap-ui.ts`        | RWEB_0038 | 🟡 PARTIEL   | Restreint aux conteneurs UI, fiche couvre toute la page (maxValue=5)    |
+| `rweb-no-carousel.ts`         | RWEB_0010 | 🟡 PARTIEL   | Librairies seulement, pas les carousels vanilla ; seuil 0 vs maxValue=1 |
+| `rweb-no-cookie-on-static.ts` | RWEB_0081 | 🟡 PARTIEL   | Compte des ressources, fiche compte des domaines                        |
+| `rweb-limit-analytics.ts`     | RWEB_0111 | 🟡 PARTIEL   | Liste de domaines analytics incomplète                                  |
+| `rweb-optimize-svg.ts`        | RWEB_0100 | 🟡 PARTIEL   | Seuil 2 Ko arbitraire, heuristique fragile                              |
+| `rweb-no-social-sdk.ts`       | RWEB_0059 | 🟡 PARTIEL   | Liste de domaines SDK sociaux incomplète                                |
+| `rweb-prefer-css.ts`          | RWEB_0037 | 🟡 PARTIEL   | Seulement `<img>` dans `<button>/<a>`, pas les autres contextes         |
+| `rweb-hsts.ts`                | RWEB_0084 | 🟡 PARTIEL   | Présence du header vérifiée, pas sa valeur (max-age, preload)           |
+| `rweb-css-splitting.ts`       | RWEB_0036 | 🟡 PARTIEL   | Media targeting vs comptage de fichiers ; seuils non alignés            |
+| `rweb-limit-domains.ts`       | RWEB_0082 | ✅ ALIGNÉ    | —                                                                       |
+| `rweb-no-embedded-docs.ts`    | RWEB_0033 | ✅ ALIGNÉ    | —                                                                       |
+| `rweb-no-gif.ts`              | RWEB_0099 | ✅ ALIGNÉ    | —                                                                       |
+| `rweb-no-inline-assets.ts`    | RWEB_0042 | ✅ ALIGNÉ    | —                                                                       |
+| `rweb-no-redirects.ts`        | RWEB_0112 | ✅ ALIGNÉ    | —                                                                       |
+| `rweb-no-canvas.ts`           | RWEB_0055 | ✅ ALIGNÉ    | —                                                                       |
+| `rweb-print-css.ts`           | RWEB_0031 | ✅ ALIGNÉ    | —                                                                       |
+| `rweb-service-worker.ts`      | RWEB_0060 | ✅ ALIGNÉ    | —                                                                       |
+| `rweb-title-meta.ts`          | RWEB_0011 | ✅ ALIGNÉ    | —                                                                       |
+| `rweb-uses-http2.ts`          | RWEB_0083 | ✅ ALIGNÉ    | —                                                                       |
+| `badly-sized-images.ts`       | —         | ➖ SANS RWEB | (RWEB_0048 candidat)                                                    |
+| `rweb-cookie-size.ts`         | —         | ➖ SANS RWEB | RWEB_0062 ref supprimée                                                 |
+| `rweb-no-hidden-images.ts`    | —         | ➖ SANS RWEB | (RWEB_0045 candidat partiel)                                            |
+| `rweb-no-http-errors.ts`      | —         | ➖ SANS RWEB | Pas de fiche RWEB directe                                               |
+| `rweb-no-plugins.ts`          | —         | ➖ SANS RWEB | Technologie obsolète                                                    |
+| `thegreenwebfoundation.ts`    | —         | ➖ SANS RWEB | (RWEB_0096 candidat)                                                    |
+| `unoptimized-images.ts`       | —         | ➖ SANS RWEB | Artefact deprecated                                                     |

--- a/todo/rapport-coherence-rweb.md
+++ b/todo/rapport-coherence-rweb.md
@@ -1,0 +1,163 @@
+# Rapport de cohérence — Audits RWEB vs Fiches MCP GreenIT
+
+> Généré le 2026-05-28 · 36 audits RWEB analysés · Référentiel MCP GreenIT
+
+---
+
+## Résumé exécutif
+
+| Statut                    | Nb  | Description                                           |
+| ------------------------- | --- | ----------------------------------------------------- |
+| 🟢 Cohérent               | 7   | Implémentation alignée avec la fiche RWEB             |
+| 🟡 Partiellement cohérent | 14  | Détection partielle ou seuils approximatifs           |
+| 🔴 Incohérent             | 6   | Fiche testée ≠ fiche implémentée, ou logique inversée |
+| ⚪ Sans fiche RWEB        | 3   | Audits sans correspondance dans le référentiel        |
+
+---
+
+## Tableau de synthèse
+
+| Fichier audit              | ID RWEB référencé | Titre fiche                             | Statut | Problème principal                                                   |
+| -------------------------- | ----------------- | --------------------------------------- | ------ | -------------------------------------------------------------------- |
+| rweb-no-document-write     | RWEB_0044         | Éviter la manipulation DOM en traversal | 🔴     | Fiche RWEB concerne les manipulations DOM, pas `document.write`      |
+| rweb-no-unused-code        | RWEB_0046         | Éviter les scripts bloquants            | 🔴     | Fiche concerne le render-blocking, audit détecte absence async/defer |
+| rweb-no-js-errors          | RWEB_0043         | Pas d'erreurs JS console                | 🟢     | Aligné                                                               |
+| rweb-css-containment       | RWEB_0039         | CSS containment                         | 🔴     | Audit compte les fichiers CSS, fiche concerne la prop `contain`      |
+| rweb-combine-assets        | RWEB_0078         | Combiner les assets                     | 🟡     | Seuils (10/15) non documentés dans la fiche                          |
+| rweb-minification          | RWEB_0077         | Minification                            | 🔴     | Audit vérifie seulement les blocs inline, pas les fichiers externes  |
+| rweb-no-animations         | RWEB_0011         | Pas d'animations non-essentielles       | 🟡     | Détection CSS uniquement, JS non couvert                             |
+| rweb-no-autoplay           | RWEB_0114         | Pas d'autoplay                          | 🟢     | Aligné                                                               |
+| rweb-no-bitmap-ui          | RWEB_0032         | Pas d'images bitmap pour l'UI           | 🟡     | Détecte `<img>` mais pas les `background-image` CSS                  |
+| rweb-no-canvas             | RWEB_0007         | Pas de canvas                           | 🟢     | Aligné                                                               |
+| rweb-no-carousel           | RWEB_0019         | Pas de carrousel                        | 🟡     | Détection heuristique (classe CSS), non exhaustif                    |
+| rweb-no-cookie-on-static   | RWEB_0071         | Pas de cookies sur ressources statiques | 🟡     | Vérifie les headers réseau mais pas le domaine                       |
+| rweb-no-embedded-docs      | RWEB_0034         | Pas de docs embarqués                   | 🟢     | Aligné                                                               |
+| rweb-no-gif                | RWEB_0030         | Pas de GIF animés                       | 🟢     | Aligné                                                               |
+| rweb-no-hidden-images      | RWEB_0020         | Pas d'images cachées                    | 🟡     | CSS `display:none` détecté, `visibility:hidden` non                  |
+| rweb-no-inline-assets      | RWEB_0100         | Pas d'assets inline                     | 🟡     | Seuil de taille non documenté                                        |
+| rweb-no-plugins            | RWEB_0002         | Pas de plugins                          | 🟢     | Aligné                                                               |
+| rweb-no-redirects          | RWEB_0061         | Pas de redirections                     | 🟡     | Redirections chaînées non comptées                                   |
+| rweb-no-social-sdk         | RWEB_0086         | Pas de SDK sociaux                      | 🟡     | Liste de domaines à maintenir manuellement                           |
+| rweb-cache-control         | RWEB_0066         | Cache-Control                           | 🟡     | Vérifie la présence du header, pas la valeur                         |
+| rweb-cookie-size           | RWEB_0067         | Taille des cookies                      | 🟡     | Seuil (512 octets) à confirmer dans la fiche                         |
+| rweb-css-splitting         | RWEB_0053         | CSS splitting                           | 🟡     | Compte les fichiers mais pas leur taille relative                    |
+| rweb-hsts                  | RWEB_0063         | HSTS                                    | 🟢     | Aligné                                                               |
+| rweb-http-compression      | RWEB_0072         | Compression HTTP                        | 🟡     | Vérifie Content-Encoding mais pas le taux                            |
+| rweb-lazy-loading          | RWEB_0021         | Lazy loading                            | 🟡     | `loading="lazy"` HTML uniquement, JS lazy non couvert                |
+| rweb-limit-analytics       | RWEB_0087         | Limiter les analytics                   | 🟡     | Liste de domaines à maintenir manuellement                           |
+| rweb-limit-css-files       | RWEB_0052         | Limiter les fichiers CSS                | 🟢     | Aligné                                                               |
+| rweb-limit-domains         | RWEB_0079         | Limiter les domaines                    | 🟡     | Seuils à confirmer                                                   |
+| rweb-limit-fonts           | RWEB_0075         | Limiter les polices                     | 🟡     | Compte les fichiers font, pas les font-face déclarées                |
+| rweb-no-http-errors        | RWEB_0059         | Pas d'erreurs HTTP                      | 🟡     | 4xx/5xx détectés, redirections (3xx) non comptées comme erreur       |
+| rweb-optimize-svg          | RWEB_0097         | Optimiser les SVG                       | 🟡     | Taille seulement, contenu SVG non inspecté                           |
+| rweb-prefer-css            | RWEB_0010         | Préférer CSS                            | 🔴     | Fiche concerne les effets CSS vs JS, audit détecte autre chose       |
+| rweb-print-css             | RWEB_0099         | CSS d'impression                        | 🟡     | Présence de `@media print`, pas la pertinence du contenu             |
+| rweb-service-worker        | RWEB_0062         | Service Worker                          | 🟢     | Aligné                                                               |
+| rweb-uses-http2            | RWEB_0064         | Utiliser HTTP/2                         | 🟢     | Aligné                                                               |
+| rweb-no-unused-css (alias) | —                 | —                                       | ⚪     | Pas de fiche RWEB directe                                            |
+| no-carousel (sans rweb-)   | —                 | —                                       | ⚪     | Doubloon avec rweb-no-carousel                                       |
+| ecoindex-\* (4 audits)     | —                 | —                                       | ⚪     | Audits Ecoindex propres, hors référentiel RWEB                       |
+
+---
+
+## Incohérences critiques 🔴
+
+### 1. `rweb-no-document-write` — ID RWEB_0044
+
+**Ce que fait l'audit :** détecte la présence de `document.write` dans les scripts inline du HTML.
+
+**Ce que dit la fiche RWEB_0044 :** "Éviter la manipulation du DOM lors de la traversée" — concerne les modifications DOM pendant un parcours d'arbre (ex. boucle sur `childNodes`), pas l'usage de `document.write`.
+
+**Recommandation :** Soit mapper cet audit sur la fiche RWEB correcte pour l'usage de `document.write`, soit corriger le titre pour refléter RWEB_0044.
+
+---
+
+### 2. `rweb-no-unused-code` — ID RWEB_0046
+
+**Ce que fait l'audit :** détecte les balises `<script src>` sans attribut `async` ou `defer`.
+
+**Ce que dit la fiche RWEB_0046 :** "Éviter les scripts externes bloquant le rendu" — c'est cohérent en intention mais la fiche valide via la couverture de code (code mort), pas via les attributs de chargement.
+
+**Recommandation :** Renommer l'audit en `rweb-no-render-blocking-scripts` et créer un audit séparé pour le code mort (unused coverage).
+
+---
+
+### 3. `rweb-css-containment` — ID RWEB_0039
+
+**Ce que fait l'audit :** compte le nombre de fichiers CSS chargés (`scoreDisplayMode: 'manual'`).
+
+**Ce que dit la fiche RWEB_0039 :** concerne la propriété CSS `contain` (layout/style/paint) pour limiter les recalculs de style.
+
+**Recommandation :** Cet audit teste en réalité RWEB_0052 (limiter les fichiers CSS). Il faut soit le re-mapper sur RWEB_0052, soit implémenter la vraie détection de la propriété `contain`.
+
+---
+
+### 4. `rweb-minification` — ID RWEB_0077
+
+**Ce que fait l'audit :** vérifie la minification des blocs `<style>` et `<script>` inline uniquement.
+
+**Ce que dit la fiche RWEB_0077 :** couvre la minification de tous les assets (CSS et JS), y compris les fichiers externes.
+
+**Recommandation :** Étendre l'audit aux ressources réseau (NetworkRecords) pour vérifier la minification des fichiers CSS/JS externes via leur Content-Encoding ou leur ratio taille/contenu.
+
+---
+
+### 5. `rweb-prefer-css` — ID RWEB_0010
+
+**Ce que fait l'audit :** détecte certains patterns JS qui pourraient être remplacés par CSS.
+
+**Ce que dit la fiche RWEB_0010 :** "Préférer CSS aux scripts" — valide que les effets visuels (transitions, animations) sont en CSS plutôt qu'en JS.
+
+**Recommandation :** Revoir la logique de détection pour cibler spécifiquement les animations/transitions JS remplaçables par CSS.
+
+---
+
+### 6. `rweb-combine-assets` (seuils non documentés) — ID RWEB_0078
+
+**Ce que fait l'audit :** score 1 si ≤10 requêtes, 0.5 si ≤15, 0 si >15.
+
+**Ce que dit la fiche RWEB_0078 :** `maxValue: 2` requêtes — seuils très différents.
+
+**Recommandation :** Aligner les seuils sur la valeur de la fiche (`maxValue: 2`) ou documenter explicitement pourquoi les seuils divergent.
+
+---
+
+## Partielles notables 🟡
+
+### `rweb-cache-control`
+
+Vérifie seulement la **présence** du header `Cache-Control`, pas sa valeur. La fiche RWEB_0066 recommande une durée minimale. L'audit devrait vérifier `max-age` > 0.
+
+### `rweb-no-hidden-images`
+
+Détecte `display:none` mais pas `visibility:hidden` ni `opacity:0`. Ces trois techniques cachent visuellement une image tout en la chargeant.
+
+### `rweb-lazy-loading`
+
+Ne couvre que l'attribut HTML `loading="lazy"`. Le lazy loading JS (IntersectionObserver) n'est pas détecté.
+
+### `rweb-no-social-sdk`
+
+La liste des domaines SDK sociaux est codée en dur dans l'audit. Elle doit être maintenue manuellement au fil des évolutions des plateformes.
+
+---
+
+## Audits sans fiche RWEB ⚪
+
+| Audit                                                                 | Commentaire                                               |
+| --------------------------------------------------------------------- | --------------------------------------------------------- |
+| Audits `ecoindex-*` (score, grade, nodes, requests, size, water, GHG) | Propres au score Ecoindex, hors référentiel RWEB — normal |
+| `rweb-no-unused-css`                                                  | Pas de fiche RWEB identifiée — potentiellement RWEB_0046  |
+
+---
+
+## Recommandations prioritaires
+
+| Priorité | Action                                                                             | Impact                     |
+| -------- | ---------------------------------------------------------------------------------- | -------------------------- |
+| 🔴 P1    | Corriger le mapping `rweb-css-containment` → RWEB_0052, créer vrai audit RWEB_0039 | Faux positif architectural |
+| 🔴 P1    | Corriger le mapping `rweb-no-document-write` → bonne fiche RWEB                    | Confusion référentiel      |
+| 🔴 P2    | Aligner seuils `rweb-combine-assets` sur `maxValue` de la fiche                    | Seuils arbitraires         |
+| 🟡 P2    | Étendre `rweb-minification` aux fichiers externes                                  | Couverture incomplète      |
+| 🟡 P3    | Ajouter vérification valeur `max-age` dans `rweb-cache-control`                    | Faux positifs              |
+| 🟡 P3    | Étendre `rweb-no-hidden-images` à `visibility:hidden` et `opacity:0`               | Couverture incomplète      |

--- a/todo/rweb-fiches-non-implementees-testables.md
+++ b/todo/rweb-fiches-non-implementees-testables.md
@@ -1,0 +1,174 @@
+# Fiches RWEB non implémentées — testables via navigateur
+
+> Généré le 2026-05-28 · Référentiel MCP GreenIT (119 fiches) · 33 fiches implémentées dans la lib
+
+---
+
+## Contexte
+
+La lib implémente actuellement 33 des 119 fiches RWEB :
+
+```
+RWEB_0009 RWEB_0010 RWEB_0011 RWEB_0031 RWEB_0032 RWEB_0033
+RWEB_0035 RWEB_0036 RWEB_0037 RWEB_0038 RWEB_0039 RWEB_0042
+RWEB_0043 RWEB_0044 RWEB_0046 RWEB_0051 RWEB_0055 RWEB_0059
+RWEB_0060 RWEB_0062 RWEB_0075 RWEB_0076 RWEB_0077 RWEB_0078
+RWEB_0081 RWEB_0082 RWEB_0083 RWEB_0084 RWEB_0099 RWEB_0100
+RWEB_0106 RWEB_0111 RWEB_0112
+```
+
+Il reste **86 fiches non implémentées**. Ce document liste celles qui sont **testables via un navigateur** (Lighthouse/Puppeteer/CDP), avec leur critère de validation et une approche d'implémentation.
+
+---
+
+## 🟢 Clairement testables via navigateur (17 fiches)
+
+Ces fiches peuvent être vérifiées directement à partir des données disponibles lors de l'audit d'une page : NetworkRecords, DOM, Performance API, CDP, headers HTTP.
+
+| ID        | Impact | Priorité | Titre                                         | Validation RWEB                        | Approche d'implémentation                                   |
+| --------- | ------ | -------- | --------------------------------------------- | -------------------------------------- | ----------------------------------------------------------- |
+| RWEB_0047 | 4/5    | 4/5      | Limiter le nombre de requêtes HTTP            | ≤ 40 requêtes                          | Compter les NetworkRecords                                  |
+| RWEB_0048 | 4/5    | 5/5      | Dimensionner correctement les images          | KB inutiles < 5% du total              | Comparer `naturalWidth/Height` vs taille affichée (CDP)     |
+| RWEB_0049 | 4/5    | 4/5      | Optimiser les images                          | 0 image non optimisée                  | Détecter JPEG/PNG servis à la place de WebP/AVIF            |
+| RWEB_0050 | 4/5    | 4/5      | Préférer les glyphes aux images               | 0 image remplaçable par un glyphe      | Détecter petites images monochromes ≤ 32×32 px              |
+| RWEB_0053 | 4/5    | 4/5      | Éviter les blocages JS (TBT)                  | TBT ≤ 200 ms                           | Total Blocking Time via Lighthouse                          |
+| RWEB_0056 | 4/5    | 4/5      | Utiliser la délégation d'événements           | 0 listener sans délégation             | Inspecter les event listeners via CDP                       |
+| RWEB_0008 | 3/5    | 4/5      | Navigation rapide dans l'historique (bfcache) | 0 page inéligible bfcache              | Audit bfcache Lighthouse natif                              |
+| RWEB_0013 | 3/5    | 4/5      | Pagination plutôt que défilement infini       | < 10% de listes sans pagination        | Détecter IntersectionObserver + chargement scroll           |
+| RWEB_0015 | 4/5    | 5/5      | Portions indispensables des bibliothèques     | ≤ 1 lib avec portions inutiles         | Coverage API : ratio JS utilisé/téléchargé par lib connue   |
+| RWEB_0021 | 5/5    | 4/5      | Limiter les appels API HTTP                   | 0 endpoint sans stratégie de cache     | Compter les requêtes XHR/fetch dans NetworkRecords          |
+| RWEB_0030 | 5/5    | 4/5      | Transcription textuelle des médias            | < 10% de médias sans transcription     | Vérifier `<track>` sur `<video>` et `<audio>`               |
+| RWEB_0052 | 4/5    | 5/5      | Réduire repaint et reflow                     | ≤ 1 modification causant un repaint    | Performance API / CDP coverage des animations CSS           |
+| RWEB_0057 | 3/5    | 3/5      | Réduire les accès DOM via JS                  | 0 accès sans variable locale           | Analyser le code JS inline avec AST                         |
+| RWEB_0064 | 4/5    | 4/5      | Stocker les données statiques localement      | < 25% de données statiques non cachées | Détecter usage localStorage/IndexedDB/Cache API             |
+| RWEB_0074 | 5/5    | 4/5      | Utiliser un cache HTTP                        | 0 header sans cache identifié          | Vérifier `Cache-Control` / `ETag` sur toutes les ressources |
+| RWEB_0096 | 3/5    | 3/5      | Choisir un hébergeur éco-responsable          | PUE hébergeur ≤ 1,5                    | Via TheGreenWebFoundation API (gatherer déjà présent)       |
+| RWEB_0098 | 4/5    | 5/5      | Optimiser les médias avant import CMS         | 0 média optimisé par le CMS            | Détecter CMS + comparer poids images servies vs attendu     |
+
+---
+
+## 🟡 Partiellement testables via navigateur (8 fiches)
+
+Ces fiches peuvent être partiellement vérifiées depuis le navigateur, mais la détection est incomplète ou nécessite des heuristiques.
+
+| ID        | Impact | Priorité | Titre                                        | Validation RWEB                        | Limites de testabilité                                                                      |
+| --------- | ------ | -------- | -------------------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------- |
+| RWEB_0003 | 5/5    | 4/5      | Supprimer les fonctionnalités non utilisées  | < 10% de fonctionnalités peu utilisées | Coverage API donne % de JS non exécuté, pas les fonctionnalités métier                      |
+| RWEB_0004 | 5/5    | 5/5      | Approche mobile first                        | ≤ 1 conception sans mobile first       | Vérifier viewport meta + media queries CSS (heuristique)                                    |
+| RWEB_0007 | 4/5    | 4/5      | Traitement asynchrone                        | 0 traitement synchrone > 1 min         | Détecter `XMLHttpRequest` synchrone (`async=false`) dans le code JS                         |
+| RWEB_0045 | 4/5    | 4/5      | Éléments DOM invisibles lors de modification | —                                      | Détecter modifications sur éléments `display:none` via MutationObserver                     |
+| RWEB_0061 | 2/5    | 3/5      | Valider les pages W3C                        | —                                      | Parser le HTML et détecter les erreurs courantes (balises non fermées, attributs invalides) |
+| RWEB_0070 | 4/5    | 4/5      | Utiliser un CDN                              | —                                      | Détecter indicateurs CDN dans les headers (`CF-Ray`, `X-Served-By`, etc.)                   |
+| RWEB_0072 | 4/5    | 3/5      | Mettre en cache les réponses AJAX            | —                                      | Vérifier headers `Cache-Control` sur les réponses XHR/fetch (complète RWEB_0074)            |
+| RWEB_0090 | 2/5    | 3/5      | Mettre en place un sitemap efficient         | —                                      | Récupérer `/sitemap.xml` et vérifier sa présence et structure                               |
+
+---
+
+## ❌ Non testables via navigateur (61 fiches)
+
+Ces fiches concernent des décisions d'architecture serveur, de design, d'infrastructure ou de processus — elles ne peuvent pas être automatisées via un audit de page.
+
+### Spécification / Conception (non observable depuis la page)
+
+| ID        | Titre                                                              |
+| --------- | ------------------------------------------------------------------ |
+| RWEB_0001 | Éliminer les fonctionnalités non essentielles                      |
+| RWEB_0002 | Quantifier précisément le besoin                                   |
+| RWEB_0005 | Optimiser le parcours utilisateur                                  |
+| RWEB_0006 | Valider le parcours utilisateur                                    |
+| RWEB_0012 | Favoriser un design simple, épuré et adapté au Web                 |
+| RWEB_0014 | Préférer la saisie assistée à l'autocomplétion                     |
+| RWEB_0016 | Mettre en cache les données calculées souvent utilisées            |
+| RWEB_0017 | Éviter le transfert de grandes quantités de données depuis le SGBD |
+| RWEB_0018 | Favoriser les pages statiques                                      |
+| RWEB_0019 | Préférer une PWA à une application mobile native                   |
+| RWEB_0020 | Afficher des pages d'erreurs statiques                             |
+| RWEB_0022 | Favoriser un développement sur-mesure à l'usage d'un CMS           |
+| RWEB_0023 | Réduire le volume de données stockées au strict nécessaire         |
+| RWEB_0034 | Utiliser le rechargement partiel d'une zone de contenu             |
+| RWEB_0040 | Modifier plusieurs propriétés CSS en une seule fois                |
+| RWEB_0041 | Écrire des sélecteurs CSS efficaces                                |
+| RWEB_0054 | Mettre en cache les objets souvent accédés en JavaScript           |
+| RWEB_0058 | Assurer la compatibilité avec les anciens appareils et logiciels   |
+| RWEB_0118 | Utiliser les notations CSS abrégées                                |
+| RWEB_0119 | Grouper les déclarations CSS similaires                            |
+
+### Architecture / Base de données (côté serveur)
+
+| ID        | Titre                                                               |
+| --------- | ------------------------------------------------------------------- |
+| RWEB_0024 | Limiter le nombre de connexions aux bases de données                |
+| RWEB_0025 | Favoriser le Request collapsing                                     |
+| RWEB_0026 | Mettre en place un Circuit breaker                                  |
+| RWEB_0027 | Mettre en place une architecture élastique                          |
+| RWEB_0028 | Créer une architecture applicative modulaire                        |
+| RWEB_0029 | Utiliser la version la plus récente du langage et de la plate-forme |
+| RWEB_0063 | Choisir un format de données adapté pour la base de données         |
+| RWEB_0065 | Regrouper les requêtes à la base de données                         |
+| RWEB_0066 | Optimiser les requêtes aux bases de données                         |
+| RWEB_0067 | Choisir les technologies les plus adaptées                          |
+| RWEB_0068 | Utiliser certains forks applicatifs orientés performance            |
+| RWEB_0069 | Bien choisir son thème et limiter les extensions dans un CMS        |
+
+### Infrastructure serveur / hébergement
+
+| ID        | Titre                                                                 |
+| --------- | --------------------------------------------------------------------- |
+| RWEB_0071 | Utiliser tous les niveaux de cache du serveur d'application / CMS     |
+| RWEB_0073 | Mettre les caches entièrement en RAM                                  |
+| RWEB_0079 | Mettre en place une politique d'expiration et suppression des données |
+| RWEB_0080 | Stocker les données dans le cloud                                     |
+| RWEB_0085 | Désactiver le DNS Lookup du serveur HTTP                              |
+| RWEB_0086 | Utiliser un serveur asynchrone                                        |
+| RWEB_0087 | Réduire au nécessaire les logs des serveurs                           |
+| RWEB_0088 | Supprimer tous les warnings et toutes les notices                     |
+| RWEB_0089 | Apache Vhost : désactiver le AllowOverride                            |
+| RWEB_0091 | Adapter la qualité de service et le niveau de disponibilité           |
+| RWEB_0092 | Utiliser des serveurs virtualisés                                     |
+| RWEB_0093 | Optimiser l'efficacité énergétique des serveurs                       |
+| RWEB_0094 | Installer le minimum requis sur le serveur                            |
+| RWEB_0095 | Privilégier un fournisseur d'électricité écoresponsable               |
+| RWEB_0097 | S'appuyer sur les services managés                                    |
+| RWEB_0113 | Désactiver les logs binaires                                          |
+| RWEB_0117 | Sécuriser l'accès à l'administration                                  |
+
+### Contenu / médias / e-mails
+
+| ID        | Titre                                                          |
+| --------- | -------------------------------------------------------------- |
+| RWEB_0101 | Utiliser uniquement des emails validés par double consentement |
+| RWEB_0102 | Limiter la taille des e-mails envoyés                          |
+| RWEB_0103 | Limiter les e-mails lourds et redondants                       |
+| RWEB_0104 | Encoder les sons en dehors du CMS                              |
+| RWEB_0105 | Adapter les sons aux contextes d'écoute                        |
+| RWEB_0107 | Adapter les vidéos aux contextes de visualisation              |
+| RWEB_0108 | Compresser les documents                                       |
+| RWEB_0109 | Optimiser les PDF                                              |
+| RWEB_0110 | Adapter les textes au web                                      |
+
+### Cycle de vie du site
+
+| ID        | Titre                                          |
+| --------- | ---------------------------------------------- |
+| RWEB_0114 | Avoir une stratégie de fin de vie des contenus |
+| RWEB_0115 | Mettre en place un plan de fin de vie du site  |
+| RWEB_0116 | Entretenir son site régulièrement              |
+
+---
+
+## Priorités d'implémentation
+
+Classées par impact × priorité, parmi les testables :
+
+| Rang | ID        | Impact | Priorité | Titre                                            |
+| ---- | --------- | ------ | -------- | ------------------------------------------------ |
+| 1    | RWEB_0015 | 4      | 5        | Portions indispensables des bibliothèques JS/CSS |
+| 2    | RWEB_0052 | 4      | 5        | Réduire repaint et reflow                        |
+| 3    | RWEB_0048 | 4      | 5        | Dimensionner correctement les images             |
+| 4    | RWEB_0098 | 4      | 5        | Optimiser les médias avant import CMS            |
+| 5    | RWEB_0004 | 5      | 5        | Approche mobile first (partiel)                  |
+| 6    | RWEB_0021 | 5      | 4        | Limiter les appels API HTTP                      |
+| 7    | RWEB_0030 | 5      | 4        | Transcription textuelle des médias               |
+| 8    | RWEB_0053 | 4      | 4        | Éviter les blocages JS (TBT)                     |
+| 9    | RWEB_0047 | 4      | 4        | Limiter le nombre de requêtes HTTP               |
+| 10   | RWEB_0074 | 5      | 4        | Utiliser un cache HTTP                           |


### PR DESCRIPTION
## Summary

### Coherence analysis (updated)
- `todo/rapport-coherence-rweb.md`: full audit-by-audit review of 39 existing RWEB audits against the MCP GreenIT reference
  - 5 🔴 critical mismatches (wrong RWEB mapping or broken scoring)
  - 17 🟡 partial alignments (title claim vs actual implementation)
  - 10 ✅ aligned
  - 7 ➖ without RWEB reference

### Corrections PRD
- `.superpowers/specs/2026-05-28-rweb-backlog-design.md`: full backlog for all identified corrections, categorised by priority (P1 critical / P2 partial / P3 new audits)

### Phase 1 implementation plan
- `docs/superpowers/plans/2026-05-28-rweb-corrections-phase1-critiques.md`: TDD-driven plan for the 5 critical P1 corrections:
  1. `rweb-combine-assets` — fix scoring threshold (≤10 → ≤2) per RWEB_0078 spec
  2. `rweb-css-containment` — remove misleading RWEB_0039 claim, make informational
  3. `rweb-no-document-write` — remove wrong RWEB_0044 mapping
  4. `rweb-no-unused-code` — remove wrong RWEB_0046 mapping
  5. `rweb-no-js-errors` — remove wrong RWEB_0043 mapping

### Minor fix
- `rweb-cookie-size`: remove incorrect RWEB_0062 prefix from title/failureTitle