### PR TITLE
feat(courses): add best-practice reports

### DIFF
--- a/.changeset/quick-tools-wink.md
+++ b/.changeset/quick-tools-wink.md
@@ -1,0 +1,7 @@
+---
+'lighthouse-plugin-ecoindex': patch
+'lighthouse-plugin-ecoindex-courses': patch
+'lighthouse-plugin-ecoindex-core': patch
+---
+
+Update Puppeteer, Lighthouse, and Lighthouse CI dependencies.

--- a/.changeset/quiet-readers-complain.md
+++ b/.changeset/quiet-readers-complain.md
@@ -1,0 +1,5 @@
+---
+'lighthouse-plugin-ecoindex-courses': minor
+---
+
+Generate JSON and Markdown reports of RWEB and generic eco-design best-practice results by course and page.

--- a/.superpowers/plans/2026-08-10-best-practices-reports.md
+++ b/.superpowers/plans/2026-08-10-best-practices-reports.md
@@ -1,0 +1,169 @@
+# Best-Practices Reports Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate JSON and Markdown reports of RWEB and generic eco-design best practices by course and page.
+
+**Architecture:** `converters.ts` extracts binary `rweb-*` and `bp-*` audit data for JSON. `printer.ts` orchestrates file reading, writes both reports, and renders Markdown including the source audit `details`. Existing E2E scenarios generate the artifacts; visual validation of their rendered Markdown remains the user's responsibility.
+
+**Tech Stack:** TypeScript, Node.js `fs`, Lighthouse User Flow results, pnpm.
+
+## Global Constraints
+
+- Keep the current responsibility split: `printer.ts` drives output; `converters.ts` holds conversion methods only.
+- Support only navigation steps (`gatherMode === 'navigation'`).
+- Include only `rweb-*` and `bp-*` audits whose score is exactly `1` or `0`.
+- Set `status: 'OK'` for score `1` and `status: 'KO'` for score `0`; retain their source order within each prefix section.
+- Each page always contains the `rweb` section titled `Bonnes pratiques RWEB` and the `bp` section titled `Bonnes pratiques generiques d'ecoconception`.
+- Reserve `<exportPath>/summary/` for aggregate outputs: `report.json`, `best-practices.report.json`, and `best-practices.report.md`; never write aggregate outputs beside course reports.
+- Trigger aggregate generation when `cliFlags.outputFiles.json` has source files, including statement mode; skip it for HTML-only runs.
+- JSON excludes `details`, `scoreDisplayMode`, `numericValue`, and `numericUnit`.
+- Markdown excludes `score`, `scoreDisplayMode`, `numericValue`, and `numericUnit`; it renders `details` only for `KO` audits in a closed native HTML `<details>` block.
+- Markdown writes `displayValue` immediately below an audit title.
+- Do not add or modify tests. Existing E2E commands remain the automated verification; the user validates rendering visually.
+- Do not add runtime dependencies.
+
+---
+
+## File Structure
+
+- Modify: `libs/ecoindex-lh-courses/src/types/index.d.ts`
+  Declares the generated JSON report structure.
+- Modify: `libs/ecoindex-lh-courses/src/converters.ts`
+  Selects and sanitizes audit values for JSON output.
+- Modify: `libs/ecoindex-lh-courses/src/printer.ts`
+  Generates aggregate files in the reserved `summary/` directory, including Markdown-only details rendering.
+- Modify: `.changeset/quiet-readers-complain.md`
+  Describes the published feature.
+
+### Task 1: Convert Best-Practice Audits
+
+**Files:**
+- Modify: `libs/ecoindex-lh-courses/src/types/index.d.ts:152-162`
+- Modify: `libs/ecoindex-lh-courses/src/converters.ts:1-150`
+
+**Interfaces:**
+- Produces: `convertBestPracticesPageResults(lhr: LH.Result): BestPracticesPage`
+- Produces: `BestPracticeAudit`, `BestPracticeSection`, `BestPracticesPage`, and `BestPracticesCourseReport`.
+
+- [ ] **Step 1: Define the generated-report types**
+
+Add these declarations to `libs/ecoindex-lh-courses/src/types/index.d.ts`:
+
+```ts
+export interface BestPracticeAudit {
+  status: 'OK' | 'KO'
+  [key: string]: unknown
+}
+
+export interface BestPracticeSection {
+  title: string
+  bestPractices: BestPracticeAudit[]
+}
+
+export interface BestPracticesPage {
+  url: string
+  rweb: BestPracticeSection
+  bp: BestPracticeSection
+}
+
+export interface BestPracticesCourseReport {
+  report: string
+  pages: BestPracticesPage[]
+}
+```
+
+- [ ] **Step 2: Implement the conversion methods in `converters.ts`**
+
+Add a private audit copy method that omits `details`, `scoreDisplayMode`, `numericValue`, and `numericUnit`; rejects scores other than exactly `0` and `1`; and adds `status` after copying. Add `convertBestPracticesPageResults` that initializes both sections, iterates `lhr.audits` in insertion order, and appends each qualifying audit to the matching `rweb` or `bp` section.
+
+- [ ] **Step 3: Verify the package compiles**
+
+Run: `pnpm --filter lighthouse-plugin-ecoindex-courses build && pnpm typecheck:strict`
+
+Expected: both commands exit with status 0.
+
+### Task 2: Generate The JSON And Markdown Reports
+
+**Files:**
+- Modify: `libs/ecoindex-lh-courses/src/printer.ts:274-351`
+
+**Interfaces:**
+- Consumes: `convertBestPracticesPageResults(lhr)` from Task 1.
+- Produces: `summary/best-practices.report.json` and `summary/best-practices.report.md` at `cliFlags.exportPath`.
+
+- [ ] **Step 1: Add JSON report orchestration**
+
+Create a private `printBestPracticesReport(cliFlags)` beside `printSummary`. It creates `<exportPath>/summary/`, reads each path in `cliFlags.outputFiles.json`, retains navigation steps, builds `BestPracticesCourseReport` values with `path.basename(jsonFile)`, and writes `summary/best-practices.report.json` with tab indentation.
+
+- [ ] **Step 2: Add Markdown report rendering in `printer.ts`**
+
+Render the report with this hierarchy: document title, course heading, page heading, `Bonnes pratiques RWEB`, then `Bonnes pratiques generiques d'ecoconception`. Render audits in source order as a level-5 heading containing `[OK]` or `[KO]` and the audit title. Write `displayValue` on the line immediately under that heading. Write remaining retained fields as Markdown bullets. Emit `Aucune bonne pratique n'est disponible.` for an empty section.
+
+Render `audit.details` only for a `KO` audit in the Markdown path. Wrap it in:
+
+```md
+<details>
+<summary>Details de l'audit</summary>
+
+...rendered content...
+
+</details>
+```
+
+For `table` and `opportunity`, use the audit headings and items to produce a Markdown table. For `list`, produce Markdown bullets. For another `details.type`, use a fenced formatted JSON block.
+
+- [ ] **Step 3: Call the new report generator**
+
+Change `printSummary` to write `summary/report.json`, then call `printBestPracticesReport(cliFlags)` in that same reserved directory. In `run.ts`, call `printSummary` whenever `cliFlags.outputFiles.json` contains source reports, rather than checking only whether the requested output includes `json`. Preserve existing summary output and log messages.
+
+- [ ] **Step 4: Verify the package compiles**
+
+Run: `pnpm --filter lighthouse-plugin-ecoindex-courses build && pnpm typecheck:strict`
+
+Expected: both commands exit with status 0.
+
+### Task 3: Validate The Existing E2E Workflow
+
+**Files:**
+- Modify: `.changeset/quiet-readers-complain.md`
+
+**Interfaces:**
+- Consumes: course report files generated by the existing E2E scenario.
+- Produces: generated best-practice report artifacts for user visual review.
+
+- [ ] **Step 1: Update release metadata**
+
+Ensure the changeset body is:
+
+```md
+Generate JSON and Markdown reports of RWEB and generic eco-design best-practice results by course and page.
+```
+
+- [ ] **Step 2: Run the existing E2E scenario**
+
+Run: `pnpm --filter @ecoindex-lh-test/courses test:file`
+
+Expected: the existing file-course scenario exits with status 0 and generates `summary/report.json`, `summary/best-practices.report.json`, and `summary/best-practices.report.md` below its timestamped report directory.
+
+- [ ] **Step 3: Present the generated Markdown for visual validation**
+
+Provide the exact generated report path to the user. The user reviews the Markdown rendering, including the headings, section split, `displayValue` placement, and collapsed details blocks.
+
+- [ ] **Step 4: Run final repository verification**
+
+Run: `pnpm format:check && pnpm lint && pnpm typecheck && pnpm typecheck:strict && pnpm test`
+
+Expected: every command exits with status 0. `pnpm test` runs sequentially through the repository script.
+
+- [ ] **Step 5: Update the knowledge graph**
+
+Run: `graphify update .`
+
+Expected: graph metadata reflects the code changes.
+
+## Plan Self-Review
+
+- Spec coverage: Tasks 1 and 2 cover prefix filtering, strict binary status, sections by prefix, excluded JSON fields, Markdown-only details, display-value placement, empty sections, and source ordering.
+- Testing: no tests are added or modified. Task 3 uses the repository's existing E2E scenario and hands visual validation to the user.
+- Responsibility split: conversion remains in `converters.ts`; report orchestration and Markdown rendering remain in `printer.ts`.

--- a/.superpowers/specs/2026-08-10-best-practices-reports-design.md
+++ b/.superpowers/specs/2026-08-10-best-practices-reports-design.md
@@ -1,0 +1,230 @@
+# Rapports de bonnes pratiques d'ecoconception
+
+## Objectif
+
+Generer, avec les rapports de synthese existants, deux exports qui recensent les
+bonnes pratiques d'ecoconception Lighthouse `rweb-*` et `bp-*`. Les exports
+doivent presenter les resultats par parcours puis par page, dans deux sections
+identifiees, en conservant les informations d'audit Lighthouse, a l'exception
+des proprietes `scoreDisplayMode`, `numericValue` et `numericUnit`. La propriete
+`details` reste absente du JSON, mais est rendue uniquement dans le Markdown.
+
+## Perimetre
+
+- Les donnees sources sont les fichiers de parcours `*.report.json` produits par
+  Lighthouse User Flows.
+- Seules les etapes dont `gatherMode` vaut `navigation` sont prises en compte.
+- Seuls les audits dont l'identifiant commence par `rweb-` ou `bp-` sont retenus.
+- Un audit de score exactement egal a `1` est exporte avec `status: "OK"`.
+- Un audit de score exactement egal a `0` est exporte avec `status: "KO"`.
+- Les audits au score partiel, `null`, absent ou non numerique sont exclus.
+- Chaque audit conserve toutes ses proprietes Lighthouse, sauf `details`,
+  `scoreDisplayMode`, `numericValue` et `numericUnit`. La propriete `details`
+  est retiree du JSON et rendue dans un bloc repliable du Markdown. Les champs
+  `title`, `description` et `displayValue` sont preserves lorsqu'ils existent
+  dans l'audit source.
+
+## Fichiers produits
+
+Les sorties agregees sont generees dans le repertoire reserve
+`<exportPath>/summary/`, distinct des rapports de parcours a la racine :
+
+- `summary/report.json`
+- `summary/best-practices.report.json`
+- `summary/best-practices.report.md`
+
+Ce namespace empeche un conflit avec un parcours dont le nom serait `summary`
+ou `best-practices`. La generation intervient avec `printSummary`, apres
+l'ecriture des rapports JSON de parcours. Elle n'est pas executee lorsqu'aucun
+rapport JSON n'est disponible.
+
+La generation depend de la presence de `cliFlags.outputFiles.json`, et non de
+la seule option `json` : elle est donc aussi executee lorsque l'option
+`statement` a produit des rapports JSON source. Avec une sortie HTML seule,
+aucun rapport agrege n'est genere.
+
+## Schema JSON
+
+Le JSON est un objet racine contenant la liste des parcours, dans le meme ordre
+que `cliFlags.outputFiles.json`. Un parcours est identifie par le nom de son
+fichier de rapport et contient ses pages dans l'ordre des etapes de navigation.
+
+```json
+{
+  "courses": [
+    {
+      "report": "example.report.json",
+      "pages": [
+        {
+          "url": "https://example.test/page",
+          "rweb": {
+            "title": "Bonnes pratiques RWEB",
+            "bestPractices": [
+            {
+              "status": "OK",
+              "id": "rweb-example-ok",
+              "title": "Example passed audit",
+              "description": "Example audit description",
+              "score": 1,
+              "displayValue": "Example passed value"
+            }
+            ]
+          },
+          "bp": {
+            "title": "Bonnes pratiques generiques d'ecoconception",
+            "bestPractices": [
+            {
+              "status": "KO",
+              "id": "bp-example-ko",
+              "title": "Example failed audit",
+              "description": "Example audit description",
+              "score": 0,
+              "displayValue": "Example failed value"
+            }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Les sections `rweb` et `bp`, avec leurs titres respectifs, sont toujours
+presentes, y compris lorsqu'elles ne contiennent aucun audit. Chaque tableau
+`bestPractices` conserve l'ordre Lighthouse au sein de sa section. Chaque entree
+est une copie de l'audit Lighthouse source, completee par le champ `status`, dont
+les seules proprietes retirees sont `details`, `scoreDisplayMode`,
+`numericValue` et `numericUnit`.
+
+## Markdown
+
+Le Markdown est une representation lisible du JSON : un titre de document, un
+niveau de titre par parcours et un niveau de titre par page. Chaque page expose
+les sections `Bonnes pratiques RWEB` et `Bonnes pratiques generiques
+ordre Lighthouse, chacun avec son statut `OK` ou `KO` et l'ensemble de ses
+proprietes hors `score`, `scoreDisplayMode`, `numericValue` et `numericUnit`.
+Seul un audit `KO` peut ajouter son contenu `details` dans un bloc repliable.
+Une section sans resultat indique explicitement qu'aucune bonne pratique n'est
+disponible.
+
+### Structure du fichier Markdown
+
+```md
+# Rapport des bonnes pratiques d'ecoconception
+
+## Parcours : <nom du fichier de rapport>
+
+### Page : <url analysee>
+
+#### Bonnes pratiques RWEB
+
+##### [OK] <title de l'audit>
+
+<displayValue de l'audit>
+
+- status: OK
+- id: rweb-<identifiant>
+- description: <description de l'audit>
+- score: 1
+- <autre propriete Lighthouse conservee>: <valeur>
+
+<details>
+<summary>Details de l'audit</summary>
+
+| URL | Taille |
+| --- | ---: |
+| https://example.test/app.js | 42 KiB |
+
+</details>
+
+##### [KO] <title de l'audit>
+
+<displayValue de l'audit>
+
+- status: KO
+- id: rweb-<identifiant>
+- description: <description de l'audit>
+- score: 0
+- <autre propriete Lighthouse conservee>: <valeur>
+
+#### Bonnes pratiques generiques d'ecoconception
+
+##### [OK] <title de l'audit>
+
+<displayValue de l'audit>
+
+- status: OK
+- id: bp-<identifiant>
+- description: <description de l'audit>
+- score: 1
+- <autre propriete Lighthouse conservee>: <valeur>
+```
+
+Les audits restent dans l'ordre Lighthouse au sein de chaque section. Le titre
+est le titre de niveau 5, et `displayValue` est ecrit immediatement sous ce
+titre. Lorsque `title`, `description` ou `displayValue` sont absents du rapport
+source, leur element est omis. Les valeurs objet ou tableau des autres
+proprietes conservees sont serialisees en JSON sur leur ligne.
+
+Lorsque `details` existe, il est affiche exclusivement dans un element HTML
+`<details>` ferme par defaut, avec le resume `Details de l'audit`. Les types
+`table` et `opportunity` sont rendus sous forme de tableau Markdown depuis leurs
+`headings` et `items`. Le type `list` est rendu sous forme de liste a puces.
+Toute autre structure est serialisee dans un bloc JSON formate. Les proprietes
+`scoreDisplayMode`, `numericValue` et `numericUnit` ne sont jamais ecrites.
+Les audits au statut `OK` ne rendent jamais de bloc `details`, meme si le rapport
+Lighthouse source en contient un.
+
+## Architecture
+
+- Un convertisseur dedie, situe dans `converters.ts`, transforme un resultat
+  Lighthouse de page en ses sections `rweb` et `bp`, en ajoutant le statut et en
+  copiant chaque audit sans les proprietes `details`, `scoreDisplayMode`,
+  `numericValue` et `numericUnit`.
+- Un second convertisseur compose les pages d'un flow en un objet de parcours.
+- `printer.ts` orchestre la lecture des rapports de parcours et ecrit les deux
+  formats. Le rendu Markdown et de `details` reste local au printer, car il n'a
+  qu'un appelant.
+- Les types exportes de `types.ts` decrivent uniquement la structure publique
+  des deux exports.
+
+## Erreurs et cas limites
+
+- Un rapport ou une etape sans audits produit des listes vides, sans interrompre
+  la generation.
+- La copie sans `details`, `scoreDisplayMode`, `numericValue` et `numericUnit`
+  est non mutante : elle ne modifie pas le rapport Lighthouse source utilise par
+  les autres sorties. Le Markdown lit `details` depuis ce rapport sans le
+  modifier.
+- Les rapports JSON invalides gardent le comportement d'erreur actuel de
+  `printSummary` : l'erreur de lecture ou de parsing est propagee.
+- Les etapes snapshot et timestamp sont ignorees, comme dans le resume actuel.
+
+## Tests
+
+- Un test de conversion verifie la selection et la repartition des audits
+  `rweb-*` et `bp-*`, l'attribution stricte du statut pour les scores `1` et
+  `0`, l'exclusion des autres scores, et la conservation de toutes les
+  proprietes d'audit sauf `details`, `scoreDisplayMode`, `numericValue` et
+  `numericUnit`, y compris `title`, `description` et `displayValue` lorsqu'elles
+  existent.
+- Un test de parcours verifie que seules les navigations sont exportees.
+- Un test du printer verifie les deux fichiers, leur structure JSON et le rendu
+  Markdown minimal, dont le rendu replie des `details` de type table, list et
+  structure inconnue.
+- La suite sequentielle `pnpm test` est executee avant livraison.
+
+## Decisions
+
+- Les scores partiels ne sont pas assimiles a un KO : la demande fixe
+  explicitement les deux valeurs binaires `1` et `0`.
+- Le rapport reste distinct de `summary.report.json` pour ne pas modifier son
+  schema existant et pour limiter les consommateurs aux donnees dont ils ont
+  besoin.
+- Les audits JSON sont copies sans `details`, `scoreDisplayMode`, `numericValue`
+  ni `numericUnit`, plutot que reconstruits champ par champ, afin de conserver
+  leurs informations et de rester compatible avec les futures proprietes
+  ajoutees par Lighthouse. Le Markdown est la seule sortie qui lit `details`.
+- Aucun enrichissement depuis le referentiel GreenIT n'est effectue : cela
+  evite des donnees redondantes et un couplage supplementaire.

--- a/apps/ecoindex-lh-cli/package.json
+++ b/apps/ecoindex-lh-cli/package.json
@@ -65,7 +65,7 @@
     "@types/yargs": "^17.0.33",
     "eslint": "^9.23.0",
     "globals": "^16.0.0",
-    "lighthouse": "13.3.0",
+    "lighthouse": "13.4.1",
     "rimraf": "^6.0.1",
     "tsup": "^8.2.0",
     "typescript": "^5.6.3",

--- a/docs/application/03-jsonmesure.md
+++ b/docs/application/03-jsonmesure.md
@@ -97,7 +97,7 @@ Vous pouvez ajouter et retirer des parcours, selon vos besoins.
 - `*.report.json` : Les rapports Lighthouse+ecoindex JSON :
   - best-pages.report.json ;
   - discovery.report.json ;
-- `summary.report.json` : Une version simplifié et fusionné des fichiers `*.report.json` ;
+- `summary/report.json` : Une version simplifié et fusionné des fichiers `*.report.json` ;
 - Fichiers statements pour la déclaration environnementale (EIS) :
   - Un fichier `README.md` expliquant comment utiliser l'EIS ;
   - Un dossier `assets` contenant des éléments images ;
@@ -115,3 +115,4 @@ Ce fichier est généré en prévision d'une lecture automatisée des EIS par de
 [!ref Rapports au format HTML](../reports/rapport-html.md)
 [!ref Rapports au format JSON Simplifié](../reports/rapport-json-summary.md)
 [!ref Rapports au format JSON Complet](../reports/rapport-json.md)
+[!ref Rapport des bonnes pratiques](../reports/rapport-best-practices.md)

--- a/docs/reports/rapport-best-practices.md
+++ b/docs/reports/rapport-best-practices.md
@@ -1,0 +1,19 @@
+---
+label: Rapport des bonnes pratiques
+icon: checklist
+order: 850
+---
+
+!!!info
+Les rapports agrégés des bonnes pratiques sont générés dans `summary/best-practices.report.json` et `summary/best-practices.report.md` lorsqu'au moins un rapport source JSON existe, y compris avec le mode de sortie `statement`.
+!!!
+
+Ils ne sont pas générés avec une sortie HTML seule. Le répertoire réservé `summary/` évite les collisions avec les noms des rapports de parcours.
+
+Les deux formats regroupent les résultats par parcours, puis par page. Chaque page sépare les bonnes pratiques RWEB, dont les identifiants commencent par `rweb-`, et les bonnes pratiques génériques, dont les identifiants commencent par `bp-`.
+
+Le statut ne retient que les scores exacts `1` et `0` : `1` devient `OK` et `0` devient `KO`. Les autres scores ne sont pas inclus.
+
+Le rapport JSON exclut les champs `details`, `scoreDisplayMode`, `numericValue` et `numericUnit`.
+
+Le rapport Markdown affiche `displayValue` sous le titre de chaque audit. Lorsque des détails Lighthouse sont disponibles, ils sont affichés dans un bloc natif fermé `<details>`.

--- a/docs/reports/rapport-best-practices.md
+++ b/docs/reports/rapport-best-practices.md
@@ -5,15 +5,12 @@ order: 850
 ---
 
 !!!info
-Les rapports agrégés des bonnes pratiques sont générés dans `summary/best-practices.report.json` et `summary/best-practices.report.md` lors d'une mesure de parcours (`cliFlags.url === undefined`) lorsqu'au moins un rapport source JSON existe, y compris avec le mode de sortie `statement`.
+Les rapports des bonnes pratiques sont générés aux formats JSON (`summary/best-practices.report.json`) et Markdown (`summary/best-practices.report.md`) lors d'une mesure de parcours.
 !!!
 
-Ils ne sont pas générés lors d'une mesure d'URL directe ni avec une sortie HTML seule. Le répertoire réservé `summary/` évite les collisions avec les noms des rapports de parcours.
+!!!warning
+Ces rapports sont générés uniquement pour les mesures de parcours avec un rapport source JSON, y compris avec le mode de sortie `statement`. Ils ne sont pas générés pour une URL directe ni avec une sortie HTML seule.
+!!!
 
-Les deux formats regroupent les résultats par parcours, puis par page. Chaque page sépare les bonnes pratiques RWEB, dont les identifiants commencent par `rweb-`, et les bonnes pratiques génériques, dont les identifiants commencent par `bp-`.
-
-Le statut ne retient que les scores exacts `1` et `0` : `1` devient `OK` et `0` devient `KO`. Les autres scores ne sont pas inclus.
-
-Le rapport JSON exclut les champs `details`, `scoreDisplayMode`, `numericValue` et `numericUnit`.
-
-Le rapport Markdown affiche `displayValue` sous le titre de chaque audit. Lorsque des détails Lighthouse sont disponibles, ils sont affichés dans un bloc natif fermé `<details>` uniquement pour les audits `KO`.
+Exemple de fichier JSON généré lors d'une mesure de parcours.
+:::code source="../static/best-practices.report.json" :::

--- a/docs/reports/rapport-best-practices.md
+++ b/docs/reports/rapport-best-practices.md
@@ -5,10 +5,10 @@ order: 850
 ---
 
 !!!info
-Les rapports agrégés des bonnes pratiques sont générés dans `summary/best-practices.report.json` et `summary/best-practices.report.md` lorsqu'au moins un rapport source JSON existe, y compris avec le mode de sortie `statement`.
+Les rapports agrégés des bonnes pratiques sont générés dans `summary/best-practices.report.json` et `summary/best-practices.report.md` lors d'une mesure de parcours (`cliFlags.url === undefined`) lorsqu'au moins un rapport source JSON existe, y compris avec le mode de sortie `statement`.
 !!!
 
-Ils ne sont pas générés avec une sortie HTML seule. Le répertoire réservé `summary/` évite les collisions avec les noms des rapports de parcours.
+Ils ne sont pas générés lors d'une mesure d'URL directe ni avec une sortie HTML seule. Le répertoire réservé `summary/` évite les collisions avec les noms des rapports de parcours.
 
 Les deux formats regroupent les résultats par parcours, puis par page. Chaque page sépare les bonnes pratiques RWEB, dont les identifiants commencent par `rweb-`, et les bonnes pratiques génériques, dont les identifiants commencent par `bp-`.
 

--- a/docs/reports/rapport-best-practices.md
+++ b/docs/reports/rapport-best-practices.md
@@ -16,4 +16,4 @@ Le statut ne retient que les scores exacts `1` et `0` : `1` devient `OK` et `0` 
 
 Le rapport JSON exclut les champs `details`, `scoreDisplayMode`, `numericValue` et `numericUnit`.
 
-Le rapport Markdown affiche `displayValue` sous le titre de chaque audit. Lorsque des détails Lighthouse sont disponibles, ils sont affichés dans un bloc natif fermé `<details>`.
+Le rapport Markdown affiche `displayValue` sous le titre de chaque audit. Lorsque des détails Lighthouse sont disponibles, ils sont affichés dans un bloc natif fermé `<details>` uniquement pour les audits `KO`.

--- a/docs/reports/rapport-json-summary.md
+++ b/docs/reports/rapport-json-summary.md
@@ -5,7 +5,7 @@ order: 900
 ---
 
 !!!info
-Rapport JSON **Summary/Simplifié** contenant les données essentielles de Lighthouse avec l'intégration des mesures et bonnes pratiques Écoindex.
+Rapport JSON **Summary/Simplifié** contenant les données essentielles de Lighthouse avec l'intégration des mesures et bonnes pratiques Écoindex. Il est généré dans `summary/report.json`.
 
 Utile, par exemple, pour faire des rapports d'audit automatisé à une date précise, sans charger les rapports Lighthouse + Ecoindex complet.
 !!!
@@ -17,5 +17,6 @@ Ce fichier n'est généré que lors de la mesure d'un parcours avec la commande
 [!ref Collect d'un parcours](../guides/1-lighthouse-ecoindex-cli.md/#command-collect)
 !!!
 
-Exemple de fichier généré lors d'une mesure de parcours.
-:::code source="../static/summary.report.json" :::
+Les rapports agrégés sont générés lorsqu'au moins un rapport source JSON est disponible, y compris avec le mode de sortie `statement`. Ils ne sont pas générés avec une sortie HTML seule.
+
+Le répertoire réservé `summary/` évite les collisions avec les noms des rapports de parcours.

--- a/docs/reports/rapport-json.md
+++ b/docs/reports/rapport-json.md
@@ -8,7 +8,7 @@ order: 500
 Rapport JSON Lighthouse **complet** avec l'intégration des mesures et bonnes pratiques Écoindex.
 !!!
 
-Les rapports JSON complets servent de sources aux rapports agrégés du répertoire `summary/`, y compris avec le mode de sortie `statement`. Aucun rapport agrégé n'est généré avec une sortie HTML seule.
+Les rapports JSON complets servent de sources aux rapports agrégés du répertoire `summary/` lors d'une mesure de parcours (`cliFlags.url === undefined`), y compris avec le mode de sortie `statement`. Aucun rapport agrégé n'est généré lors d'une mesure d'URL directe ni avec une sortie HTML seule.
 
 !!!warning
 Ce type de fichier est au format brut Lighthouse et est difficilement exploitable, de préférence, utilisez la version simplifiée.

--- a/docs/reports/rapport-json.md
+++ b/docs/reports/rapport-json.md
@@ -8,6 +8,8 @@ order: 500
 Rapport JSON Lighthouse **complet** avec l'intégration des mesures et bonnes pratiques Écoindex.
 !!!
 
+Les rapports JSON complets servent de sources aux rapports agrégés du répertoire `summary/`, y compris avec le mode de sortie `statement`. Aucun rapport agrégé n'est généré avec une sortie HTML seule.
+
 !!!warning
 Ce type de fichier est au format brut Lighthouse et est difficilement exploitable, de préférence, utilisez la version simplifiée.
 [!ref Rapport au format JSON Simplifé](rapport-json-summary.md)

--- a/docs/static/best-practices.report.json
+++ b/docs/static/best-practices.report.json
@@ -1,0 +1,3332 @@
+{
+  "courses": [
+    {
+      "report": "simple-test-page.report.json",
+      "pages": [
+        {
+          "url": "http://localhost:3000/simple",
+          "rweb": {
+            "title": "Bonnes pratiques RWEB",
+            "bestPractices": [
+              {
+                "id": "rweb-no-animations",
+                "title": "RWEB_0009 - No animated elements",
+                "description": "Avoid animations and transitions to reduce CPU and battery usage. [See RWEB_0009](https://rweb.greenit.fr/en/fiches/RWEB_0009-avoid-javascriptcss-animations)",
+                "score": 1,
+                "displayValue": "No animated elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-carousel",
+                "title": "RWEB_0010 - Avoid carousels",
+                "description": "Avoid using carousel/slider libraries when possible. [See RWEB_0010](https://rweb.greenit.fr/en/fiches/RWEB_0010-limiting-the-use-of-carousels)",
+                "score": 1,
+                "displayValue": "No carousel libraries detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-title-meta",
+                "title": "RWEB_0011 - Missing title or meta description",
+                "description": "Ensure the page has a non-empty title and meta description. [See RWEB_0011](https://rweb.greenit.fr/en/fiches/RWEB_0011-relevant-page-titles-and-metadescriptions)",
+                "score": 0,
+                "displayValue": "Missing title or meta description",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-print-css",
+                "title": "RWEB_0031 - No print css implemented.",
+                "description": "A print css must be implemented to hide useless elements when printing. [See RWEB_0031](https://rweb.greenit.fr/en/fiches/RWEB_0031-provide-a-css-print)",
+                "score": 0,
+                "displayValue": "Print CSS count: 0",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-limit-fonts",
+                "title": "RWEB_0032 - Limit font families (≤ 2)",
+                "description": "Reduce the number of external font families loaded. [See RWEB_0032](https://rweb.greenit.fr/en/fiches/RWEB_0032-prefer-standard-fonts)",
+                "score": 1,
+                "displayValue": "0 external font families",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-embedded-docs",
+                "title": "RWEB_0033 - No embedded documents",
+                "description": "Avoid embedding documents (PDF, Word, etc.) directly in HTML. Use links instead. [See RWEB_0033](https://rweb.greenit.fr/en/fiches/RWEB_0033-do-not-display-documents-within-pages)",
+                "score": 1,
+                "displayValue": "No embedded documents detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-css-files",
+                "title": "RWEB_0035 - Limit CSS stylesheets (≤ 7)",
+                "description": "Keep the number of CSS files to 7 or fewer to reduce HTTP requests. [See RWEB_0035](https://rweb.greenit.fr/en/fiches/RWEB_0035-limit-the-number-of-css)",
+                "score": 1,
+                "displayValue": "0 CSS stylesheet(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-css-splitting",
+                "title": "RWEB_0036 - Split CSS by media context",
+                "description": "Split large CSS files by media type (print, mobile…) so only relevant styles are parsed. [See RWEB_0036](https://rweb.greenit.fr/en/fiches/RWEB_0036-divide-css)",
+                "score": 1,
+                "displayValue": "All large CSS files are scoped by media type",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-prefer-css",
+                "title": "RWEB_0037 - Prefer CSS over images for UI elements",
+                "description": "Replace bitmap or SVG icons inside buttons and links with CSS shapes or icon fonts to reduce HTTP requests. [See RWEB_0037](https://rweb.greenit.fr/en/fiches/RWEB_0037-use-css-instead-of-images)",
+                "score": 1,
+                "displayValue": "No icon images in buttons/links detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-bitmap-ui",
+                "title": "RWEB_0038 - Avoid bitmap images for UI elements",
+                "description": "Replace bitmap images (PNG/JPG/WebP) in headers, navs, footers and buttons with SVG or CSS. [See RWEB_0038](https://rweb.greenit.fr/en/fiches/RWEB_0038-avoid-using-raster-images-for-the-interface)",
+                "score": 1,
+                "displayValue": "No bitmap images in UI containers",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-inline-assets",
+                "title": "RWEB_0042 - Minimize inline assets",
+                "description": "Minimize the use of inline scripts and styles. [See RWEB_0042](https://rweb.greenit.fr/en/fiches/RWEB_0042-externalize-css-and-javascript)",
+                "score": 1,
+                "displayValue": "1 inline asset(s) found",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-lazy-loading",
+                "title": "RWEB_0051 - Use lazy loading for images",
+                "description": "Add loading=\"lazy\" to below-the-fold images to defer their download. [See RWEB_0051](https://rweb.greenit.fr/en/fiches/RWEB_0051-use-lazy-loading)",
+                "score": 1,
+                "displayValue": "All images use lazy loading",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-canvas",
+                "title": "RWEB_0055 - Avoid canvas elements",
+                "description": "Minimize the use of canvas elements. [See RWEB_0055](https://rweb.greenit.fr/en/fiches/RWEB_0055-limit-canvas-use)",
+                "score": 1,
+                "displayValue": "No canvas elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-social-sdk",
+                "title": "RWEB_0059 - No official social network buttons",
+                "description": "Replace official social network buttons with static links to reduce third-party requests. [See RWEB_0059](https://rweb.greenit.fr/en/fiches/RWEB_0059-replace-the-official-social-network-sharing-buttons)",
+                "score": 1,
+                "displayValue": "0 social SDK request(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-service-worker",
+                "title": "RWEB_0060 - No active Service Worker detected",
+                "description": "A Service Worker improves caching and reduces network requests. [See RWEB_0060](https://rweb.greenit.fr/en/fiches/RWEB_0060-save-bandwidth-with-service-workers)",
+                "score": 0,
+                "displayValue": "No Service Worker",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-cache-control",
+                "title": "RWEB_0075 - Use Cache-Control headers",
+                "description": "Set Cache-Control headers on HTML, CSS, JS and font resources to reduce repeated downloads. [See RWEB_0075](https://rweb.greenit.fr/en/fiches/RWEB_0075-add-expires-or-cache-control-headers)",
+                "score": 1,
+                "displayValue": "All resources have Cache-Control",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-http-compression",
+                "title": "RWEB_0076 - Text resources not compressed",
+                "description": "Enable gzip/brotli compression for HTML, CSS and JS resources. [See RWEB_0076](https://rweb.greenit.fr/en/fiches/RWEB_0076-compressing-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "0/1 text resources compressed (0%)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-minification",
+                "title": "RWEB_0077 - Minify inline CSS and JS",
+                "description": "Minify inline style and script blocks to reduce page weight. [See RWEB_0077](https://rweb.greenit.fr/en/fiches/RWEB_0077-minifying-text-files-css-js-html-and-svg)",
+                "score": 1,
+                "displayValue": "All inline assets appear minified",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-combine-assets",
+                "title": "RWEB_0078 - Combine CSS and JS files (≤2 each)",
+                "description": "Concatenate CSS and JS files to reduce HTTP requests. [See RWEB_0078](https://rweb.greenit.fr/en/fiches/RWEB_0078-combining-css-and-javascript-files)",
+                "score": 1,
+                "displayValue": "0 CSS + 0 JS files",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-cookie-on-static",
+                "title": "RWEB_0081 - No cookies on static resources",
+                "description": "Avoid sending cookies with static resources (images, CSS, JS, fonts). [See RWEB_0081](https://rweb.greenit.fr/en/fiches/RWEB_0081-host-static-resources-on-a-cookie-free-domain)",
+                "score": 1,
+                "displayValue": "No static resources with Cookie header",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-domains",
+                "title": "RWEB_0082 - Limit resource domains (≤ 5)",
+                "description": "Reduce the number of unique domains serving page resources. [See RWEB_0082](https://rweb.greenit.fr/en/fiches/RWEB_0082-limit-the-number-of-domains-serving-resources)",
+                "score": 1,
+                "displayValue": "1 unique domain(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-uses-http2",
+                "title": "RWEB_0083 - Resources served over HTTP/1",
+                "description": "Use HTTP/2 to benefit from multiplexing and header compression. [See RWEB_0083](https://rweb.greenit.fr/en/fiches/RWEB_0083-http2-over-http1)",
+                "score": 0,
+                "displayValue": "1 resource(s) on HTTP/1",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-hsts",
+                "title": "RWEB_0084 - HSTS header missing",
+                "description": "Enable HSTS (HTTP Strict-Transport-Security) header to enforce HTTPS. [See RWEB_0084](https://rweb.greenit.fr/en/fiches/RWEB_0084-favor-hsts-preload-list-over-301-redirects)",
+                "score": 0,
+                "displayValue": "HSTS header is missing",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-gif",
+                "title": "RWEB_0099 - Avoid using GIFs",
+                "description": "Avoid using GIFs for animations or images; use modern formats instead. [See RWEB_0099](https://rweb.greenit.fr/en/fiches/RWEB_0099-limit-the-use-of-animated-gif)",
+                "score": 1,
+                "displayValue": "No GIFs detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-optimize-svg",
+                "title": "RWEB_0100 - Optimize SVG files",
+                "description": "SVG files over 2048 bytes likely contain metadata or comments that can be removed. [See RWEB_0100](https://rweb.greenit.fr/en/fiches/RWEB_0100-optimize-vector-images)",
+                "score": 1,
+                "displayValue": "All SVG files appear optimized",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-autoplay",
+                "title": "RWEB_0106 - No video/audio autoplay",
+                "description": "Avoid autoplay on video and audio elements. [See RWEB_0106](https://rweb.greenit.fr/es/fiches/RWEB_0106-evitar-la-reproduccion-y-carga-automatica-de-videos-y-sonidos)",
+                "score": 1,
+                "displayValue": "0 autoplay element(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-analytics",
+                "title": "RWEB_0111 - Limit analytics tools (≤ 1)",
+                "description": "Limit analytics tools to one per page. [See RWEB_0111](https://rweb.greenit.fr/es/fiches/RWEB_0111-limitar-las-herramientas-de-analisis-y-los-datos-recopilados)",
+                "score": 1,
+                "displayValue": "0 analytics tool(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-redirects",
+                "title": "RWEB_0112 - Avoid HTTP redirects (≤ 1)",
+                "description": "Reduce HTTP redirects to avoid unnecessary round trips. [See RWEB_0112](https://rweb.greenit.fr/en/fiches/RWEB_0112-avoir-redirections)",
+                "score": 1,
+                "displayValue": "0 redirect(s)",
+                "status": "OK"
+              }
+            ]
+          },
+          "bp": {
+            "title": "Bonnes pratiques generiques d'ecoconception",
+            "bestPractices": [
+              {
+                "id": "bp-badly-sized-images",
+                "title": "Do not resize images in the browser",
+                "description": "Do not resize images using the HTML attributes height and width. This sends images in their original size, wasting bandwidth and processor power. A PNG-24 image measuring 350 x 300 px is 41 KB. If you were to resize the same image file in HTML and display it as a 70 x 60 px thumbnail, it would still be 41 KB, when in fact it should be no more than 3 KB! This means 38 KB downloaded for nothing. The best solution is to resize images using software such as Photoshop, without using HTML. When the content added by website users has no specific added value, it",
+                "score": 1,
+                "displayValue": "Found 0 resized image(s)",
+                "status": "OK"
+              },
+              {
+                "id": "bp-cookie-size",
+                "title": "Cookie size ≤ 512 bytes",
+                "description": "Keep Cookie request headers under 512 bytes to reduce HTTP overhead.",
+                "score": 1,
+                "displayValue": "No Cookie header exceeds 512 bytes",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-http-errors",
+                "title": "Avoid HTTP request errors (4xx/5xx)",
+                "description": "Fix broken resources (404, 500…) to avoid unnecessary network load and improve user experience.",
+                "score": 1,
+                "displayValue": "No HTTP errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-document-write",
+                "title": "Avoid blocking DOM write API in inline scripts",
+                "description": "Using the deprecated DOM write API blocks HTML parsing and forces a full browser re-parse. Replace it with modern DOM manipulation methods (e.g. element.insertAdjacentHTML or appendChild).",
+                "score": 1,
+                "displayValue": "No blocking DOM write API detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-hidden-images",
+                "title": "Avoid downloading images that are not displayed",
+                "description": "Images that are downloaded but hidden waste bandwidth. Use lazy loading or remove them.",
+                "score": 1,
+                "displayValue": "No hidden downloaded images",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-js-errors",
+                "title": "No JavaScript runtime errors in console",
+                "description": "Fix JavaScript errors detected at runtime. These are console.error() calls recorded during page load and indicate broken features. Unlike static linting (RWEB_0043), this check does not cover code style or syntax issues.",
+                "score": 1,
+                "displayValue": "No JavaScript runtime errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-plugins",
+                "title": "Do not use browser plugins (Flash, Silverlight, Java)",
+                "description": "Remove Flash, Silverlight and Java applet elements — these plugins are obsolete, insecure and unsupported.",
+                "score": 1,
+                "displayValue": "No browser plugins detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-unused-code",
+                "title": "Avoid render-blocking external scripts",
+                "description": "Add async or defer to external scripts to prevent blocking the critical rendering path. Render-blocking scripts delay page display and increase CPU usage unnecessarily.",
+                "score": 1,
+                "displayValue": "No render-blocking external scripts",
+                "status": "OK"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "report": "shadow-dom-test.report.json",
+      "pages": [
+        {
+          "url": "http://localhost:3000/shadow-dom",
+          "rweb": {
+            "title": "Bonnes pratiques RWEB",
+            "bestPractices": [
+              {
+                "id": "rweb-no-animations",
+                "title": "RWEB_0009 - No animated elements",
+                "description": "Avoid animations and transitions to reduce CPU and battery usage. [See RWEB_0009](https://rweb.greenit.fr/en/fiches/RWEB_0009-avoid-javascriptcss-animations)",
+                "score": 1,
+                "displayValue": "No animated elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-carousel",
+                "title": "RWEB_0010 - Avoid carousels",
+                "description": "Avoid using carousel/slider libraries when possible. [See RWEB_0010](https://rweb.greenit.fr/en/fiches/RWEB_0010-limiting-the-use-of-carousels)",
+                "score": 1,
+                "displayValue": "No carousel libraries detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-title-meta",
+                "title": "RWEB_0011 - Missing title or meta description",
+                "description": "Ensure the page has a non-empty title and meta description. [See RWEB_0011](https://rweb.greenit.fr/en/fiches/RWEB_0011-relevant-page-titles-and-metadescriptions)",
+                "score": 0,
+                "displayValue": "Missing title or meta description",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-print-css",
+                "title": "RWEB_0031 - No print css implemented.",
+                "description": "A print css must be implemented to hide useless elements when printing. [See RWEB_0031](https://rweb.greenit.fr/en/fiches/RWEB_0031-provide-a-css-print)",
+                "score": 0,
+                "displayValue": "Print CSS count: 0",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-limit-fonts",
+                "title": "RWEB_0032 - Limit font families (≤ 2)",
+                "description": "Reduce the number of external font families loaded. [See RWEB_0032](https://rweb.greenit.fr/en/fiches/RWEB_0032-prefer-standard-fonts)",
+                "score": 1,
+                "displayValue": "0 external font families",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-embedded-docs",
+                "title": "RWEB_0033 - No embedded documents",
+                "description": "Avoid embedding documents (PDF, Word, etc.) directly in HTML. Use links instead. [See RWEB_0033](https://rweb.greenit.fr/en/fiches/RWEB_0033-do-not-display-documents-within-pages)",
+                "score": 1,
+                "displayValue": "No embedded documents detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-css-files",
+                "title": "RWEB_0035 - Limit CSS stylesheets (≤ 7)",
+                "description": "Keep the number of CSS files to 7 or fewer to reduce HTTP requests. [See RWEB_0035](https://rweb.greenit.fr/en/fiches/RWEB_0035-limit-the-number-of-css)",
+                "score": 1,
+                "displayValue": "0 CSS stylesheet(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-css-splitting",
+                "title": "RWEB_0036 - Split CSS by media context",
+                "description": "Split large CSS files by media type (print, mobile…) so only relevant styles are parsed. [See RWEB_0036](https://rweb.greenit.fr/en/fiches/RWEB_0036-divide-css)",
+                "score": 1,
+                "displayValue": "All large CSS files are scoped by media type",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-prefer-css",
+                "title": "RWEB_0037 - Prefer CSS over images for UI elements",
+                "description": "Replace bitmap or SVG icons inside buttons and links with CSS shapes or icon fonts to reduce HTTP requests. [See RWEB_0037](https://rweb.greenit.fr/en/fiches/RWEB_0037-use-css-instead-of-images)",
+                "score": 1,
+                "displayValue": "No icon images in buttons/links detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-bitmap-ui",
+                "title": "RWEB_0038 - Avoid bitmap images for UI elements",
+                "description": "Replace bitmap images (PNG/JPG/WebP) in headers, navs, footers and buttons with SVG or CSS. [See RWEB_0038](https://rweb.greenit.fr/en/fiches/RWEB_0038-avoid-using-raster-images-for-the-interface)",
+                "score": 1,
+                "displayValue": "No bitmap images in UI containers",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-inline-assets",
+                "title": "RWEB_0042 - Minimize inline assets",
+                "description": "Minimize the use of inline scripts and styles. [See RWEB_0042](https://rweb.greenit.fr/en/fiches/RWEB_0042-externalize-css-and-javascript)",
+                "score": 1,
+                "displayValue": "2 inline asset(s) found",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-lazy-loading",
+                "title": "RWEB_0051 - Use lazy loading for images",
+                "description": "Add loading=\"lazy\" to below-the-fold images to defer their download. [See RWEB_0051](https://rweb.greenit.fr/en/fiches/RWEB_0051-use-lazy-loading)",
+                "score": 1,
+                "displayValue": "All images use lazy loading",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-canvas",
+                "title": "RWEB_0055 - Avoid canvas elements",
+                "description": "Minimize the use of canvas elements. [See RWEB_0055](https://rweb.greenit.fr/en/fiches/RWEB_0055-limit-canvas-use)",
+                "score": 1,
+                "displayValue": "No canvas elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-social-sdk",
+                "title": "RWEB_0059 - No official social network buttons",
+                "description": "Replace official social network buttons with static links to reduce third-party requests. [See RWEB_0059](https://rweb.greenit.fr/en/fiches/RWEB_0059-replace-the-official-social-network-sharing-buttons)",
+                "score": 1,
+                "displayValue": "0 social SDK request(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-service-worker",
+                "title": "RWEB_0060 - No active Service Worker detected",
+                "description": "A Service Worker improves caching and reduces network requests. [See RWEB_0060](https://rweb.greenit.fr/en/fiches/RWEB_0060-save-bandwidth-with-service-workers)",
+                "score": 0,
+                "displayValue": "No Service Worker",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-cache-control",
+                "title": "RWEB_0075 - Use Cache-Control headers",
+                "description": "Set Cache-Control headers on HTML, CSS, JS and font resources to reduce repeated downloads. [See RWEB_0075](https://rweb.greenit.fr/en/fiches/RWEB_0075-add-expires-or-cache-control-headers)",
+                "score": 1,
+                "displayValue": "All resources have Cache-Control",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-http-compression",
+                "title": "RWEB_0076 - Text resources not compressed",
+                "description": "Enable gzip/brotli compression for HTML, CSS and JS resources. [See RWEB_0076](https://rweb.greenit.fr/en/fiches/RWEB_0076-compressing-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "0/1 text resources compressed (0%)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-minification",
+                "title": "RWEB_0077 - Unminified inline CSS/JS detected",
+                "description": "Minify inline style and script blocks to reduce page weight. [See RWEB_0077](https://rweb.greenit.fr/en/fiches/RWEB_0077-minifying-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "2 unminified inline asset(s)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-combine-assets",
+                "title": "RWEB_0078 - Combine CSS and JS files (≤2 each)",
+                "description": "Concatenate CSS and JS files to reduce HTTP requests. [See RWEB_0078](https://rweb.greenit.fr/en/fiches/RWEB_0078-combining-css-and-javascript-files)",
+                "score": 1,
+                "displayValue": "0 CSS + 0 JS files",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-cookie-on-static",
+                "title": "RWEB_0081 - No cookies on static resources",
+                "description": "Avoid sending cookies with static resources (images, CSS, JS, fonts). [See RWEB_0081](https://rweb.greenit.fr/en/fiches/RWEB_0081-host-static-resources-on-a-cookie-free-domain)",
+                "score": 1,
+                "displayValue": "No static resources with Cookie header",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-domains",
+                "title": "RWEB_0082 - Limit resource domains (≤ 5)",
+                "description": "Reduce the number of unique domains serving page resources. [See RWEB_0082](https://rweb.greenit.fr/en/fiches/RWEB_0082-limit-the-number-of-domains-serving-resources)",
+                "score": 1,
+                "displayValue": "1 unique domain(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-uses-http2",
+                "title": "RWEB_0083 - Resources served over HTTP/1",
+                "description": "Use HTTP/2 to benefit from multiplexing and header compression. [See RWEB_0083](https://rweb.greenit.fr/en/fiches/RWEB_0083-http2-over-http1)",
+                "score": 0,
+                "displayValue": "1 resource(s) on HTTP/1",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-hsts",
+                "title": "RWEB_0084 - HSTS header missing",
+                "description": "Enable HSTS (HTTP Strict-Transport-Security) header to enforce HTTPS. [See RWEB_0084](https://rweb.greenit.fr/en/fiches/RWEB_0084-favor-hsts-preload-list-over-301-redirects)",
+                "score": 0,
+                "displayValue": "HSTS header is missing",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-gif",
+                "title": "RWEB_0099 - Avoid using GIFs",
+                "description": "Avoid using GIFs for animations or images; use modern formats instead. [See RWEB_0099](https://rweb.greenit.fr/en/fiches/RWEB_0099-limit-the-use-of-animated-gif)",
+                "score": 1,
+                "displayValue": "No GIFs detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-optimize-svg",
+                "title": "RWEB_0100 - Optimize SVG files",
+                "description": "SVG files over 2048 bytes likely contain metadata or comments that can be removed. [See RWEB_0100](https://rweb.greenit.fr/en/fiches/RWEB_0100-optimize-vector-images)",
+                "score": 1,
+                "displayValue": "All SVG files appear optimized",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-autoplay",
+                "title": "RWEB_0106 - No video/audio autoplay",
+                "description": "Avoid autoplay on video and audio elements. [See RWEB_0106](https://rweb.greenit.fr/es/fiches/RWEB_0106-evitar-la-reproduccion-y-carga-automatica-de-videos-y-sonidos)",
+                "score": 1,
+                "displayValue": "0 autoplay element(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-analytics",
+                "title": "RWEB_0111 - Limit analytics tools (≤ 1)",
+                "description": "Limit analytics tools to one per page. [See RWEB_0111](https://rweb.greenit.fr/es/fiches/RWEB_0111-limitar-las-herramientas-de-analisis-y-los-datos-recopilados)",
+                "score": 1,
+                "displayValue": "0 analytics tool(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-redirects",
+                "title": "RWEB_0112 - Avoid HTTP redirects (≤ 1)",
+                "description": "Reduce HTTP redirects to avoid unnecessary round trips. [See RWEB_0112](https://rweb.greenit.fr/en/fiches/RWEB_0112-avoir-redirections)",
+                "score": 1,
+                "displayValue": "0 redirect(s)",
+                "status": "OK"
+              }
+            ]
+          },
+          "bp": {
+            "title": "Bonnes pratiques generiques d'ecoconception",
+            "bestPractices": [
+              {
+                "id": "bp-badly-sized-images",
+                "title": "Do not resize images in the browser",
+                "description": "Do not resize images using the HTML attributes height and width. This sends images in their original size, wasting bandwidth and processor power. A PNG-24 image measuring 350 x 300 px is 41 KB. If you were to resize the same image file in HTML and display it as a 70 x 60 px thumbnail, it would still be 41 KB, when in fact it should be no more than 3 KB! This means 38 KB downloaded for nothing. The best solution is to resize images using software such as Photoshop, without using HTML. When the content added by website users has no specific added value, it",
+                "score": 1,
+                "displayValue": "Found 0 resized image(s)",
+                "status": "OK"
+              },
+              {
+                "id": "bp-cookie-size",
+                "title": "Cookie size ≤ 512 bytes",
+                "description": "Keep Cookie request headers under 512 bytes to reduce HTTP overhead.",
+                "score": 1,
+                "displayValue": "No Cookie header exceeds 512 bytes",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-http-errors",
+                "title": "Avoid HTTP request errors (4xx/5xx)",
+                "description": "Fix broken resources (404, 500…) to avoid unnecessary network load and improve user experience.",
+                "score": 1,
+                "displayValue": "No HTTP errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-document-write",
+                "title": "Avoid blocking DOM write API in inline scripts",
+                "description": "Using the deprecated DOM write API blocks HTML parsing and forces a full browser re-parse. Replace it with modern DOM manipulation methods (e.g. element.insertAdjacentHTML or appendChild).",
+                "score": 1,
+                "displayValue": "No blocking DOM write API detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-hidden-images",
+                "title": "Avoid downloading images that are not displayed",
+                "description": "Images that are downloaded but hidden waste bandwidth. Use lazy loading or remove them.",
+                "score": 1,
+                "displayValue": "No hidden downloaded images",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-js-errors",
+                "title": "No JavaScript runtime errors in console",
+                "description": "Fix JavaScript errors detected at runtime. These are console.error() calls recorded during page load and indicate broken features. Unlike static linting (RWEB_0043), this check does not cover code style or syntax issues.",
+                "score": 1,
+                "displayValue": "No JavaScript runtime errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-plugins",
+                "title": "Do not use browser plugins (Flash, Silverlight, Java)",
+                "description": "Remove Flash, Silverlight and Java applet elements — these plugins are obsolete, insecure and unsupported.",
+                "score": 1,
+                "displayValue": "No browser plugins detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-unused-code",
+                "title": "Avoid render-blocking external scripts",
+                "description": "Add async or defer to external scripts to prevent blocking the critical rendering path. Render-blocking scripts delay page display and increase CPU usage unnecessarily.",
+                "score": 1,
+                "displayValue": "No render-blocking external scripts",
+                "status": "OK"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "report": "complex-test.report.json",
+      "pages": [
+        {
+          "url": "http://localhost:3000/svg-shadow-dom",
+          "rweb": {
+            "title": "Bonnes pratiques RWEB",
+            "bestPractices": [
+              {
+                "id": "rweb-no-animations",
+                "title": "RWEB_0009 - No animated elements",
+                "description": "Avoid animations and transitions to reduce CPU and battery usage. [See RWEB_0009](https://rweb.greenit.fr/en/fiches/RWEB_0009-avoid-javascriptcss-animations)",
+                "score": 1,
+                "displayValue": "No animated elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-carousel",
+                "title": "RWEB_0010 - Avoid carousels",
+                "description": "Avoid using carousel/slider libraries when possible. [See RWEB_0010](https://rweb.greenit.fr/en/fiches/RWEB_0010-limiting-the-use-of-carousels)",
+                "score": 1,
+                "displayValue": "No carousel libraries detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-title-meta",
+                "title": "RWEB_0011 - Missing title or meta description",
+                "description": "Ensure the page has a non-empty title and meta description. [See RWEB_0011](https://rweb.greenit.fr/en/fiches/RWEB_0011-relevant-page-titles-and-metadescriptions)",
+                "score": 0,
+                "displayValue": "Missing title or meta description",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-print-css",
+                "title": "RWEB_0031 - No print css implemented.",
+                "description": "A print css must be implemented to hide useless elements when printing. [See RWEB_0031](https://rweb.greenit.fr/en/fiches/RWEB_0031-provide-a-css-print)",
+                "score": 0,
+                "displayValue": "Print CSS count: 0",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-limit-fonts",
+                "title": "RWEB_0032 - Limit font families (≤ 2)",
+                "description": "Reduce the number of external font families loaded. [See RWEB_0032](https://rweb.greenit.fr/en/fiches/RWEB_0032-prefer-standard-fonts)",
+                "score": 1,
+                "displayValue": "0 external font families",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-embedded-docs",
+                "title": "RWEB_0033 - No embedded documents",
+                "description": "Avoid embedding documents (PDF, Word, etc.) directly in HTML. Use links instead. [See RWEB_0033](https://rweb.greenit.fr/en/fiches/RWEB_0033-do-not-display-documents-within-pages)",
+                "score": 1,
+                "displayValue": "No embedded documents detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-css-files",
+                "title": "RWEB_0035 - Limit CSS stylesheets (≤ 7)",
+                "description": "Keep the number of CSS files to 7 or fewer to reduce HTTP requests. [See RWEB_0035](https://rweb.greenit.fr/en/fiches/RWEB_0035-limit-the-number-of-css)",
+                "score": 1,
+                "displayValue": "0 CSS stylesheet(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-css-splitting",
+                "title": "RWEB_0036 - Split CSS by media context",
+                "description": "Split large CSS files by media type (print, mobile…) so only relevant styles are parsed. [See RWEB_0036](https://rweb.greenit.fr/en/fiches/RWEB_0036-divide-css)",
+                "score": 1,
+                "displayValue": "All large CSS files are scoped by media type",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-prefer-css",
+                "title": "RWEB_0037 - Prefer CSS over images for UI elements",
+                "description": "Replace bitmap or SVG icons inside buttons and links with CSS shapes or icon fonts to reduce HTTP requests. [See RWEB_0037](https://rweb.greenit.fr/en/fiches/RWEB_0037-use-css-instead-of-images)",
+                "score": 1,
+                "displayValue": "No icon images in buttons/links detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-bitmap-ui",
+                "title": "RWEB_0038 - Avoid bitmap images for UI elements",
+                "description": "Replace bitmap images (PNG/JPG/WebP) in headers, navs, footers and buttons with SVG or CSS. [See RWEB_0038](https://rweb.greenit.fr/en/fiches/RWEB_0038-avoid-using-raster-images-for-the-interface)",
+                "score": 1,
+                "displayValue": "No bitmap images in UI containers",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-inline-assets",
+                "title": "RWEB_0042 - Minimize inline assets",
+                "description": "Minimize the use of inline scripts and styles. [See RWEB_0042](https://rweb.greenit.fr/en/fiches/RWEB_0042-externalize-css-and-javascript)",
+                "score": 1,
+                "displayValue": "2 inline asset(s) found",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-lazy-loading",
+                "title": "RWEB_0051 - Use lazy loading for images",
+                "description": "Add loading=\"lazy\" to below-the-fold images to defer their download. [See RWEB_0051](https://rweb.greenit.fr/en/fiches/RWEB_0051-use-lazy-loading)",
+                "score": 1,
+                "displayValue": "All images use lazy loading",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-canvas",
+                "title": "RWEB_0055 - Avoid canvas elements",
+                "description": "Minimize the use of canvas elements. [See RWEB_0055](https://rweb.greenit.fr/en/fiches/RWEB_0055-limit-canvas-use)",
+                "score": 1,
+                "displayValue": "No canvas elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-social-sdk",
+                "title": "RWEB_0059 - No official social network buttons",
+                "description": "Replace official social network buttons with static links to reduce third-party requests. [See RWEB_0059](https://rweb.greenit.fr/en/fiches/RWEB_0059-replace-the-official-social-network-sharing-buttons)",
+                "score": 1,
+                "displayValue": "0 social SDK request(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-service-worker",
+                "title": "RWEB_0060 - No active Service Worker detected",
+                "description": "A Service Worker improves caching and reduces network requests. [See RWEB_0060](https://rweb.greenit.fr/en/fiches/RWEB_0060-save-bandwidth-with-service-workers)",
+                "score": 0,
+                "displayValue": "No Service Worker",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-cache-control",
+                "title": "RWEB_0075 - Use Cache-Control headers",
+                "description": "Set Cache-Control headers on HTML, CSS, JS and font resources to reduce repeated downloads. [See RWEB_0075](https://rweb.greenit.fr/en/fiches/RWEB_0075-add-expires-or-cache-control-headers)",
+                "score": 1,
+                "displayValue": "All resources have Cache-Control",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-http-compression",
+                "title": "RWEB_0076 - Text resources not compressed",
+                "description": "Enable gzip/brotli compression for HTML, CSS and JS resources. [See RWEB_0076](https://rweb.greenit.fr/en/fiches/RWEB_0076-compressing-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "0/1 text resources compressed (0%)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-minification",
+                "title": "RWEB_0077 - Unminified inline CSS/JS detected",
+                "description": "Minify inline style and script blocks to reduce page weight. [See RWEB_0077](https://rweb.greenit.fr/en/fiches/RWEB_0077-minifying-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "2 unminified inline asset(s)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-combine-assets",
+                "title": "RWEB_0078 - Combine CSS and JS files (≤2 each)",
+                "description": "Concatenate CSS and JS files to reduce HTTP requests. [See RWEB_0078](https://rweb.greenit.fr/en/fiches/RWEB_0078-combining-css-and-javascript-files)",
+                "score": 1,
+                "displayValue": "0 CSS + 0 JS files",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-cookie-on-static",
+                "title": "RWEB_0081 - No cookies on static resources",
+                "description": "Avoid sending cookies with static resources (images, CSS, JS, fonts). [See RWEB_0081](https://rweb.greenit.fr/en/fiches/RWEB_0081-host-static-resources-on-a-cookie-free-domain)",
+                "score": 1,
+                "displayValue": "No static resources with Cookie header",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-domains",
+                "title": "RWEB_0082 - Limit resource domains (≤ 5)",
+                "description": "Reduce the number of unique domains serving page resources. [See RWEB_0082](https://rweb.greenit.fr/en/fiches/RWEB_0082-limit-the-number-of-domains-serving-resources)",
+                "score": 1,
+                "displayValue": "1 unique domain(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-uses-http2",
+                "title": "RWEB_0083 - Resources served over HTTP/1",
+                "description": "Use HTTP/2 to benefit from multiplexing and header compression. [See RWEB_0083](https://rweb.greenit.fr/en/fiches/RWEB_0083-http2-over-http1)",
+                "score": 0,
+                "displayValue": "1 resource(s) on HTTP/1",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-hsts",
+                "title": "RWEB_0084 - HSTS header missing",
+                "description": "Enable HSTS (HTTP Strict-Transport-Security) header to enforce HTTPS. [See RWEB_0084](https://rweb.greenit.fr/en/fiches/RWEB_0084-favor-hsts-preload-list-over-301-redirects)",
+                "score": 0,
+                "displayValue": "HSTS header is missing",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-gif",
+                "title": "RWEB_0099 - Avoid using GIFs",
+                "description": "Avoid using GIFs for animations or images; use modern formats instead. [See RWEB_0099](https://rweb.greenit.fr/en/fiches/RWEB_0099-limit-the-use-of-animated-gif)",
+                "score": 1,
+                "displayValue": "No GIFs detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-optimize-svg",
+                "title": "RWEB_0100 - Optimize SVG files",
+                "description": "SVG files over 2048 bytes likely contain metadata or comments that can be removed. [See RWEB_0100](https://rweb.greenit.fr/en/fiches/RWEB_0100-optimize-vector-images)",
+                "score": 1,
+                "displayValue": "All SVG files appear optimized",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-autoplay",
+                "title": "RWEB_0106 - No video/audio autoplay",
+                "description": "Avoid autoplay on video and audio elements. [See RWEB_0106](https://rweb.greenit.fr/es/fiches/RWEB_0106-evitar-la-reproduccion-y-carga-automatica-de-videos-y-sonidos)",
+                "score": 1,
+                "displayValue": "0 autoplay element(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-analytics",
+                "title": "RWEB_0111 - Limit analytics tools (≤ 1)",
+                "description": "Limit analytics tools to one per page. [See RWEB_0111](https://rweb.greenit.fr/es/fiches/RWEB_0111-limitar-las-herramientas-de-analisis-y-los-datos-recopilados)",
+                "score": 1,
+                "displayValue": "0 analytics tool(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-redirects",
+                "title": "RWEB_0112 - Avoid HTTP redirects (≤ 1)",
+                "description": "Reduce HTTP redirects to avoid unnecessary round trips. [See RWEB_0112](https://rweb.greenit.fr/en/fiches/RWEB_0112-avoir-redirections)",
+                "score": 1,
+                "displayValue": "0 redirect(s)",
+                "status": "OK"
+              }
+            ]
+          },
+          "bp": {
+            "title": "Bonnes pratiques generiques d'ecoconception",
+            "bestPractices": [
+              {
+                "id": "bp-badly-sized-images",
+                "title": "Do not resize images in the browser",
+                "description": "Do not resize images using the HTML attributes height and width. This sends images in their original size, wasting bandwidth and processor power. A PNG-24 image measuring 350 x 300 px is 41 KB. If you were to resize the same image file in HTML and display it as a 70 x 60 px thumbnail, it would still be 41 KB, when in fact it should be no more than 3 KB! This means 38 KB downloaded for nothing. The best solution is to resize images using software such as Photoshop, without using HTML. When the content added by website users has no specific added value, it",
+                "score": 1,
+                "displayValue": "Found 0 resized image(s)",
+                "status": "OK"
+              },
+              {
+                "id": "bp-cookie-size",
+                "title": "Cookie size ≤ 512 bytes",
+                "description": "Keep Cookie request headers under 512 bytes to reduce HTTP overhead.",
+                "score": 1,
+                "displayValue": "No Cookie header exceeds 512 bytes",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-http-errors",
+                "title": "Avoid HTTP request errors (4xx/5xx)",
+                "description": "Fix broken resources (404, 500…) to avoid unnecessary network load and improve user experience.",
+                "score": 1,
+                "displayValue": "No HTTP errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-document-write",
+                "title": "Avoid blocking DOM write API in inline scripts",
+                "description": "Using the deprecated DOM write API blocks HTML parsing and forces a full browser re-parse. Replace it with modern DOM manipulation methods (e.g. element.insertAdjacentHTML or appendChild).",
+                "score": 1,
+                "displayValue": "No blocking DOM write API detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-hidden-images",
+                "title": "Avoid downloading images that are not displayed",
+                "description": "Images that are downloaded but hidden waste bandwidth. Use lazy loading or remove them.",
+                "score": 1,
+                "displayValue": "No hidden downloaded images",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-js-errors",
+                "title": "No JavaScript runtime errors in console",
+                "description": "Fix JavaScript errors detected at runtime. These are console.error() calls recorded during page load and indicate broken features. Unlike static linting (RWEB_0043), this check does not cover code style or syntax issues.",
+                "score": 1,
+                "displayValue": "No JavaScript runtime errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-plugins",
+                "title": "Do not use browser plugins (Flash, Silverlight, Java)",
+                "description": "Remove Flash, Silverlight and Java applet elements — these plugins are obsolete, insecure and unsupported.",
+                "score": 1,
+                "displayValue": "No browser plugins detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-unused-code",
+                "title": "Avoid render-blocking external scripts",
+                "description": "Add async or defer to external scripts to prevent blocking the critical rendering path. Render-blocking scripts delay page display and increase CPU usage unnecessarily.",
+                "score": 1,
+                "displayValue": "No render-blocking external scripts",
+                "status": "OK"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "report": "heavy-impact-test.report.json",
+      "pages": [
+        {
+          "url": "http://localhost:3000/heavy",
+          "rweb": {
+            "title": "Bonnes pratiques RWEB",
+            "bestPractices": [
+              {
+                "id": "rweb-no-animations",
+                "title": "RWEB_0009 - No animated elements",
+                "description": "Avoid animations and transitions to reduce CPU and battery usage. [See RWEB_0009](https://rweb.greenit.fr/en/fiches/RWEB_0009-avoid-javascriptcss-animations)",
+                "score": 1,
+                "displayValue": "No animated elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-carousel",
+                "title": "RWEB_0010 - Avoid carousels",
+                "description": "Avoid using carousel/slider libraries when possible. [See RWEB_0010](https://rweb.greenit.fr/en/fiches/RWEB_0010-limiting-the-use-of-carousels)",
+                "score": 1,
+                "displayValue": "No carousel libraries detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-title-meta",
+                "title": "RWEB_0011 - Missing title or meta description",
+                "description": "Ensure the page has a non-empty title and meta description. [See RWEB_0011](https://rweb.greenit.fr/en/fiches/RWEB_0011-relevant-page-titles-and-metadescriptions)",
+                "score": 0,
+                "displayValue": "Missing title or meta description",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-print-css",
+                "title": "RWEB_0031 - No print css implemented.",
+                "description": "A print css must be implemented to hide useless elements when printing. [See RWEB_0031](https://rweb.greenit.fr/en/fiches/RWEB_0031-provide-a-css-print)",
+                "score": 0,
+                "displayValue": "Print CSS count: 0",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-limit-fonts",
+                "title": "RWEB_0032 - Limit font families (≤ 2)",
+                "description": "Reduce the number of external font families loaded. [See RWEB_0032](https://rweb.greenit.fr/en/fiches/RWEB_0032-prefer-standard-fonts)",
+                "score": 1,
+                "displayValue": "0 external font families",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-embedded-docs",
+                "title": "RWEB_0033 - No embedded documents",
+                "description": "Avoid embedding documents (PDF, Word, etc.) directly in HTML. Use links instead. [See RWEB_0033](https://rweb.greenit.fr/en/fiches/RWEB_0033-do-not-display-documents-within-pages)",
+                "score": 1,
+                "displayValue": "No embedded documents detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-css-files",
+                "title": "RWEB_0035 - Limit CSS stylesheets (≤ 7)",
+                "description": "Keep the number of CSS files to 7 or fewer to reduce HTTP requests. [See RWEB_0035](https://rweb.greenit.fr/en/fiches/RWEB_0035-limit-the-number-of-css)",
+                "score": 1,
+                "displayValue": "0 CSS stylesheet(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-css-splitting",
+                "title": "RWEB_0036 - Split CSS by media context",
+                "description": "Split large CSS files by media type (print, mobile…) so only relevant styles are parsed. [See RWEB_0036](https://rweb.greenit.fr/en/fiches/RWEB_0036-divide-css)",
+                "score": 1,
+                "displayValue": "All large CSS files are scoped by media type",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-prefer-css",
+                "title": "RWEB_0037 - Prefer CSS over images for UI elements",
+                "description": "Replace bitmap or SVG icons inside buttons and links with CSS shapes or icon fonts to reduce HTTP requests. [See RWEB_0037](https://rweb.greenit.fr/en/fiches/RWEB_0037-use-css-instead-of-images)",
+                "score": 1,
+                "displayValue": "No icon images in buttons/links detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-bitmap-ui",
+                "title": "RWEB_0038 - Avoid bitmap images for UI elements",
+                "description": "Replace bitmap images (PNG/JPG/WebP) in headers, navs, footers and buttons with SVG or CSS. [See RWEB_0038](https://rweb.greenit.fr/en/fiches/RWEB_0038-avoid-using-raster-images-for-the-interface)",
+                "score": 1,
+                "displayValue": "No bitmap images in UI containers",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-inline-assets",
+                "title": "RWEB_0042 - Minimize inline assets",
+                "description": "Minimize the use of inline scripts and styles. [See RWEB_0042](https://rweb.greenit.fr/en/fiches/RWEB_0042-externalize-css-and-javascript)",
+                "score": 1,
+                "displayValue": "1 inline asset(s) found",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-lazy-loading",
+                "title": "RWEB_0051 - Use lazy loading for images",
+                "description": "Add loading=\"lazy\" to below-the-fold images to defer their download. [See RWEB_0051](https://rweb.greenit.fr/en/fiches/RWEB_0051-use-lazy-loading)",
+                "score": 1,
+                "displayValue": "All images use lazy loading",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-canvas",
+                "title": "RWEB_0055 - Avoid canvas elements",
+                "description": "Minimize the use of canvas elements. [See RWEB_0055](https://rweb.greenit.fr/en/fiches/RWEB_0055-limit-canvas-use)",
+                "score": 1,
+                "displayValue": "No canvas elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-social-sdk",
+                "title": "RWEB_0059 - No official social network buttons",
+                "description": "Replace official social network buttons with static links to reduce third-party requests. [See RWEB_0059](https://rweb.greenit.fr/en/fiches/RWEB_0059-replace-the-official-social-network-sharing-buttons)",
+                "score": 1,
+                "displayValue": "0 social SDK request(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-service-worker",
+                "title": "RWEB_0060 - No active Service Worker detected",
+                "description": "A Service Worker improves caching and reduces network requests. [See RWEB_0060](https://rweb.greenit.fr/en/fiches/RWEB_0060-save-bandwidth-with-service-workers)",
+                "score": 0,
+                "displayValue": "No Service Worker",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-cache-control",
+                "title": "RWEB_0075 - Use Cache-Control headers",
+                "description": "Set Cache-Control headers on HTML, CSS, JS and font resources to reduce repeated downloads. [See RWEB_0075](https://rweb.greenit.fr/en/fiches/RWEB_0075-add-expires-or-cache-control-headers)",
+                "score": 1,
+                "displayValue": "All resources have Cache-Control",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-http-compression",
+                "title": "RWEB_0076 - Text resources not compressed",
+                "description": "Enable gzip/brotli compression for HTML, CSS and JS resources. [See RWEB_0076](https://rweb.greenit.fr/en/fiches/RWEB_0076-compressing-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "0/1 text resources compressed (0%)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-minification",
+                "title": "RWEB_0077 - Unminified inline CSS/JS detected",
+                "description": "Minify inline style and script blocks to reduce page weight. [See RWEB_0077](https://rweb.greenit.fr/en/fiches/RWEB_0077-minifying-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "1 unminified inline asset(s)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-combine-assets",
+                "title": "RWEB_0078 - Combine CSS and JS files (≤2 each)",
+                "description": "Concatenate CSS and JS files to reduce HTTP requests. [See RWEB_0078](https://rweb.greenit.fr/en/fiches/RWEB_0078-combining-css-and-javascript-files)",
+                "score": 1,
+                "displayValue": "0 CSS + 0 JS files",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-cookie-on-static",
+                "title": "RWEB_0081 - No cookies on static resources",
+                "description": "Avoid sending cookies with static resources (images, CSS, JS, fonts). [See RWEB_0081](https://rweb.greenit.fr/en/fiches/RWEB_0081-host-static-resources-on-a-cookie-free-domain)",
+                "score": 1,
+                "displayValue": "No static resources with Cookie header",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-domains",
+                "title": "RWEB_0082 - Limit resource domains (≤ 5)",
+                "description": "Reduce the number of unique domains serving page resources. [See RWEB_0082](https://rweb.greenit.fr/en/fiches/RWEB_0082-limit-the-number-of-domains-serving-resources)",
+                "score": 1,
+                "displayValue": "1 unique domain(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-uses-http2",
+                "title": "RWEB_0083 - Resources served over HTTP/1",
+                "description": "Use HTTP/2 to benefit from multiplexing and header compression. [See RWEB_0083](https://rweb.greenit.fr/en/fiches/RWEB_0083-http2-over-http1)",
+                "score": 0,
+                "displayValue": "1 resource(s) on HTTP/1",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-hsts",
+                "title": "RWEB_0084 - HSTS header missing",
+                "description": "Enable HSTS (HTTP Strict-Transport-Security) header to enforce HTTPS. [See RWEB_0084](https://rweb.greenit.fr/en/fiches/RWEB_0084-favor-hsts-preload-list-over-301-redirects)",
+                "score": 0,
+                "displayValue": "HSTS header is missing",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-gif",
+                "title": "RWEB_0099 - Avoid using GIFs",
+                "description": "Avoid using GIFs for animations or images; use modern formats instead. [See RWEB_0099](https://rweb.greenit.fr/en/fiches/RWEB_0099-limit-the-use-of-animated-gif)",
+                "score": 1,
+                "displayValue": "No GIFs detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-optimize-svg",
+                "title": "RWEB_0100 - Optimize SVG files",
+                "description": "SVG files over 2048 bytes likely contain metadata or comments that can be removed. [See RWEB_0100](https://rweb.greenit.fr/en/fiches/RWEB_0100-optimize-vector-images)",
+                "score": 1,
+                "displayValue": "All SVG files appear optimized",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-autoplay",
+                "title": "RWEB_0106 - No video/audio autoplay",
+                "description": "Avoid autoplay on video and audio elements. [See RWEB_0106](https://rweb.greenit.fr/es/fiches/RWEB_0106-evitar-la-reproduccion-y-carga-automatica-de-videos-y-sonidos)",
+                "score": 1,
+                "displayValue": "0 autoplay element(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-analytics",
+                "title": "RWEB_0111 - Limit analytics tools (≤ 1)",
+                "description": "Limit analytics tools to one per page. [See RWEB_0111](https://rweb.greenit.fr/es/fiches/RWEB_0111-limitar-las-herramientas-de-analisis-y-los-datos-recopilados)",
+                "score": 1,
+                "displayValue": "0 analytics tool(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-redirects",
+                "title": "RWEB_0112 - Avoid HTTP redirects (≤ 1)",
+                "description": "Reduce HTTP redirects to avoid unnecessary round trips. [See RWEB_0112](https://rweb.greenit.fr/en/fiches/RWEB_0112-avoir-redirections)",
+                "score": 1,
+                "displayValue": "0 redirect(s)",
+                "status": "OK"
+              }
+            ]
+          },
+          "bp": {
+            "title": "Bonnes pratiques generiques d'ecoconception",
+            "bestPractices": [
+              {
+                "id": "bp-badly-sized-images",
+                "title": "Do not resize images in the browser",
+                "description": "Do not resize images using the HTML attributes height and width. This sends images in their original size, wasting bandwidth and processor power. A PNG-24 image measuring 350 x 300 px is 41 KB. If you were to resize the same image file in HTML and display it as a 70 x 60 px thumbnail, it would still be 41 KB, when in fact it should be no more than 3 KB! This means 38 KB downloaded for nothing. The best solution is to resize images using software such as Photoshop, without using HTML. When the content added by website users has no specific added value, it",
+                "score": 1,
+                "displayValue": "Found 0 resized image(s)",
+                "status": "OK"
+              },
+              {
+                "id": "bp-cookie-size",
+                "title": "Cookie size ≤ 512 bytes",
+                "description": "Keep Cookie request headers under 512 bytes to reduce HTTP overhead.",
+                "score": 1,
+                "displayValue": "No Cookie header exceeds 512 bytes",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-http-errors",
+                "title": "Avoid HTTP request errors (4xx/5xx)",
+                "description": "Fix broken resources (404, 500…) to avoid unnecessary network load and improve user experience.",
+                "score": 1,
+                "displayValue": "No HTTP errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-document-write",
+                "title": "Avoid blocking DOM write API in inline scripts",
+                "description": "Using the deprecated DOM write API blocks HTML parsing and forces a full browser re-parse. Replace it with modern DOM manipulation methods (e.g. element.insertAdjacentHTML or appendChild).",
+                "score": 1,
+                "displayValue": "No blocking DOM write API detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-hidden-images",
+                "title": "Avoid downloading images that are not displayed",
+                "description": "Images that are downloaded but hidden waste bandwidth. Use lazy loading or remove them.",
+                "score": 1,
+                "displayValue": "No hidden downloaded images",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-js-errors",
+                "title": "No JavaScript runtime errors in console",
+                "description": "Fix JavaScript errors detected at runtime. These are console.error() calls recorded during page load and indicate broken features. Unlike static linting (RWEB_0043), this check does not cover code style or syntax issues.",
+                "score": 1,
+                "displayValue": "No JavaScript runtime errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-plugins",
+                "title": "Do not use browser plugins (Flash, Silverlight, Java)",
+                "description": "Remove Flash, Silverlight and Java applet elements — these plugins are obsolete, insecure and unsupported.",
+                "score": 1,
+                "displayValue": "No browser plugins detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-unused-code",
+                "title": "Avoid render-blocking external scripts",
+                "description": "Add async or defer to external scripts to prevent blocking the critical rendering path. Render-blocking scripts delay page display and increase CPU usage unnecessarily.",
+                "score": 1,
+                "displayValue": "No render-blocking external scripts",
+                "status": "OK"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "report": "complete-test-suite.report.json",
+      "pages": [
+        {
+          "url": "http://localhost:3000/simple",
+          "rweb": {
+            "title": "Bonnes pratiques RWEB",
+            "bestPractices": [
+              {
+                "id": "rweb-no-animations",
+                "title": "RWEB_0009 - No animated elements",
+                "description": "Avoid animations and transitions to reduce CPU and battery usage. [See RWEB_0009](https://rweb.greenit.fr/en/fiches/RWEB_0009-avoid-javascriptcss-animations)",
+                "score": 1,
+                "displayValue": "No animated elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-carousel",
+                "title": "RWEB_0010 - Avoid carousels",
+                "description": "Avoid using carousel/slider libraries when possible. [See RWEB_0010](https://rweb.greenit.fr/en/fiches/RWEB_0010-limiting-the-use-of-carousels)",
+                "score": 1,
+                "displayValue": "No carousel libraries detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-title-meta",
+                "title": "RWEB_0011 - Missing title or meta description",
+                "description": "Ensure the page has a non-empty title and meta description. [See RWEB_0011](https://rweb.greenit.fr/en/fiches/RWEB_0011-relevant-page-titles-and-metadescriptions)",
+                "score": 0,
+                "displayValue": "Missing title or meta description",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-print-css",
+                "title": "RWEB_0031 - No print css implemented.",
+                "description": "A print css must be implemented to hide useless elements when printing. [See RWEB_0031](https://rweb.greenit.fr/en/fiches/RWEB_0031-provide-a-css-print)",
+                "score": 0,
+                "displayValue": "Print CSS count: 0",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-limit-fonts",
+                "title": "RWEB_0032 - Limit font families (≤ 2)",
+                "description": "Reduce the number of external font families loaded. [See RWEB_0032](https://rweb.greenit.fr/en/fiches/RWEB_0032-prefer-standard-fonts)",
+                "score": 1,
+                "displayValue": "0 external font families",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-embedded-docs",
+                "title": "RWEB_0033 - No embedded documents",
+                "description": "Avoid embedding documents (PDF, Word, etc.) directly in HTML. Use links instead. [See RWEB_0033](https://rweb.greenit.fr/en/fiches/RWEB_0033-do-not-display-documents-within-pages)",
+                "score": 1,
+                "displayValue": "No embedded documents detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-css-files",
+                "title": "RWEB_0035 - Limit CSS stylesheets (≤ 7)",
+                "description": "Keep the number of CSS files to 7 or fewer to reduce HTTP requests. [See RWEB_0035](https://rweb.greenit.fr/en/fiches/RWEB_0035-limit-the-number-of-css)",
+                "score": 1,
+                "displayValue": "0 CSS stylesheet(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-css-splitting",
+                "title": "RWEB_0036 - Split CSS by media context",
+                "description": "Split large CSS files by media type (print, mobile…) so only relevant styles are parsed. [See RWEB_0036](https://rweb.greenit.fr/en/fiches/RWEB_0036-divide-css)",
+                "score": 1,
+                "displayValue": "All large CSS files are scoped by media type",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-prefer-css",
+                "title": "RWEB_0037 - Prefer CSS over images for UI elements",
+                "description": "Replace bitmap or SVG icons inside buttons and links with CSS shapes or icon fonts to reduce HTTP requests. [See RWEB_0037](https://rweb.greenit.fr/en/fiches/RWEB_0037-use-css-instead-of-images)",
+                "score": 1,
+                "displayValue": "No icon images in buttons/links detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-bitmap-ui",
+                "title": "RWEB_0038 - Avoid bitmap images for UI elements",
+                "description": "Replace bitmap images (PNG/JPG/WebP) in headers, navs, footers and buttons with SVG or CSS. [See RWEB_0038](https://rweb.greenit.fr/en/fiches/RWEB_0038-avoid-using-raster-images-for-the-interface)",
+                "score": 1,
+                "displayValue": "No bitmap images in UI containers",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-inline-assets",
+                "title": "RWEB_0042 - Minimize inline assets",
+                "description": "Minimize the use of inline scripts and styles. [See RWEB_0042](https://rweb.greenit.fr/en/fiches/RWEB_0042-externalize-css-and-javascript)",
+                "score": 1,
+                "displayValue": "1 inline asset(s) found",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-lazy-loading",
+                "title": "RWEB_0051 - Use lazy loading for images",
+                "description": "Add loading=\"lazy\" to below-the-fold images to defer their download. [See RWEB_0051](https://rweb.greenit.fr/en/fiches/RWEB_0051-use-lazy-loading)",
+                "score": 1,
+                "displayValue": "All images use lazy loading",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-canvas",
+                "title": "RWEB_0055 - Avoid canvas elements",
+                "description": "Minimize the use of canvas elements. [See RWEB_0055](https://rweb.greenit.fr/en/fiches/RWEB_0055-limit-canvas-use)",
+                "score": 1,
+                "displayValue": "No canvas elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-social-sdk",
+                "title": "RWEB_0059 - No official social network buttons",
+                "description": "Replace official social network buttons with static links to reduce third-party requests. [See RWEB_0059](https://rweb.greenit.fr/en/fiches/RWEB_0059-replace-the-official-social-network-sharing-buttons)",
+                "score": 1,
+                "displayValue": "0 social SDK request(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-service-worker",
+                "title": "RWEB_0060 - No active Service Worker detected",
+                "description": "A Service Worker improves caching and reduces network requests. [See RWEB_0060](https://rweb.greenit.fr/en/fiches/RWEB_0060-save-bandwidth-with-service-workers)",
+                "score": 0,
+                "displayValue": "No Service Worker",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-cache-control",
+                "title": "RWEB_0075 - Use Cache-Control headers",
+                "description": "Set Cache-Control headers on HTML, CSS, JS and font resources to reduce repeated downloads. [See RWEB_0075](https://rweb.greenit.fr/en/fiches/RWEB_0075-add-expires-or-cache-control-headers)",
+                "score": 1,
+                "displayValue": "All resources have Cache-Control",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-http-compression",
+                "title": "RWEB_0076 - Text resources not compressed",
+                "description": "Enable gzip/brotli compression for HTML, CSS and JS resources. [See RWEB_0076](https://rweb.greenit.fr/en/fiches/RWEB_0076-compressing-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "0/1 text resources compressed (0%)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-minification",
+                "title": "RWEB_0077 - Minify inline CSS and JS",
+                "description": "Minify inline style and script blocks to reduce page weight. [See RWEB_0077](https://rweb.greenit.fr/en/fiches/RWEB_0077-minifying-text-files-css-js-html-and-svg)",
+                "score": 1,
+                "displayValue": "All inline assets appear minified",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-combine-assets",
+                "title": "RWEB_0078 - Combine CSS and JS files (≤2 each)",
+                "description": "Concatenate CSS and JS files to reduce HTTP requests. [See RWEB_0078](https://rweb.greenit.fr/en/fiches/RWEB_0078-combining-css-and-javascript-files)",
+                "score": 1,
+                "displayValue": "0 CSS + 0 JS files",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-cookie-on-static",
+                "title": "RWEB_0081 - No cookies on static resources",
+                "description": "Avoid sending cookies with static resources (images, CSS, JS, fonts). [See RWEB_0081](https://rweb.greenit.fr/en/fiches/RWEB_0081-host-static-resources-on-a-cookie-free-domain)",
+                "score": 1,
+                "displayValue": "No static resources with Cookie header",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-domains",
+                "title": "RWEB_0082 - Limit resource domains (≤ 5)",
+                "description": "Reduce the number of unique domains serving page resources. [See RWEB_0082](https://rweb.greenit.fr/en/fiches/RWEB_0082-limit-the-number-of-domains-serving-resources)",
+                "score": 1,
+                "displayValue": "1 unique domain(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-uses-http2",
+                "title": "RWEB_0083 - Resources served over HTTP/1",
+                "description": "Use HTTP/2 to benefit from multiplexing and header compression. [See RWEB_0083](https://rweb.greenit.fr/en/fiches/RWEB_0083-http2-over-http1)",
+                "score": 0,
+                "displayValue": "1 resource(s) on HTTP/1",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-hsts",
+                "title": "RWEB_0084 - HSTS header missing",
+                "description": "Enable HSTS (HTTP Strict-Transport-Security) header to enforce HTTPS. [See RWEB_0084](https://rweb.greenit.fr/en/fiches/RWEB_0084-favor-hsts-preload-list-over-301-redirects)",
+                "score": 0,
+                "displayValue": "HSTS header is missing",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-gif",
+                "title": "RWEB_0099 - Avoid using GIFs",
+                "description": "Avoid using GIFs for animations or images; use modern formats instead. [See RWEB_0099](https://rweb.greenit.fr/en/fiches/RWEB_0099-limit-the-use-of-animated-gif)",
+                "score": 1,
+                "displayValue": "No GIFs detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-optimize-svg",
+                "title": "RWEB_0100 - Optimize SVG files",
+                "description": "SVG files over 2048 bytes likely contain metadata or comments that can be removed. [See RWEB_0100](https://rweb.greenit.fr/en/fiches/RWEB_0100-optimize-vector-images)",
+                "score": 1,
+                "displayValue": "All SVG files appear optimized",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-autoplay",
+                "title": "RWEB_0106 - No video/audio autoplay",
+                "description": "Avoid autoplay on video and audio elements. [See RWEB_0106](https://rweb.greenit.fr/es/fiches/RWEB_0106-evitar-la-reproduccion-y-carga-automatica-de-videos-y-sonidos)",
+                "score": 1,
+                "displayValue": "0 autoplay element(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-analytics",
+                "title": "RWEB_0111 - Limit analytics tools (≤ 1)",
+                "description": "Limit analytics tools to one per page. [See RWEB_0111](https://rweb.greenit.fr/es/fiches/RWEB_0111-limitar-las-herramientas-de-analisis-y-los-datos-recopilados)",
+                "score": 1,
+                "displayValue": "0 analytics tool(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-redirects",
+                "title": "RWEB_0112 - Avoid HTTP redirects (≤ 1)",
+                "description": "Reduce HTTP redirects to avoid unnecessary round trips. [See RWEB_0112](https://rweb.greenit.fr/en/fiches/RWEB_0112-avoir-redirections)",
+                "score": 1,
+                "displayValue": "0 redirect(s)",
+                "status": "OK"
+              }
+            ]
+          },
+          "bp": {
+            "title": "Bonnes pratiques generiques d'ecoconception",
+            "bestPractices": [
+              {
+                "id": "bp-badly-sized-images",
+                "title": "Do not resize images in the browser",
+                "description": "Do not resize images using the HTML attributes height and width. This sends images in their original size, wasting bandwidth and processor power. A PNG-24 image measuring 350 x 300 px is 41 KB. If you were to resize the same image file in HTML and display it as a 70 x 60 px thumbnail, it would still be 41 KB, when in fact it should be no more than 3 KB! This means 38 KB downloaded for nothing. The best solution is to resize images using software such as Photoshop, without using HTML. When the content added by website users has no specific added value, it",
+                "score": 1,
+                "displayValue": "Found 0 resized image(s)",
+                "status": "OK"
+              },
+              {
+                "id": "bp-cookie-size",
+                "title": "Cookie size ≤ 512 bytes",
+                "description": "Keep Cookie request headers under 512 bytes to reduce HTTP overhead.",
+                "score": 1,
+                "displayValue": "No Cookie header exceeds 512 bytes",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-http-errors",
+                "title": "Avoid HTTP request errors (4xx/5xx)",
+                "description": "Fix broken resources (404, 500…) to avoid unnecessary network load and improve user experience.",
+                "score": 1,
+                "displayValue": "No HTTP errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-document-write",
+                "title": "Avoid blocking DOM write API in inline scripts",
+                "description": "Using the deprecated DOM write API blocks HTML parsing and forces a full browser re-parse. Replace it with modern DOM manipulation methods (e.g. element.insertAdjacentHTML or appendChild).",
+                "score": 1,
+                "displayValue": "No blocking DOM write API detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-hidden-images",
+                "title": "Avoid downloading images that are not displayed",
+                "description": "Images that are downloaded but hidden waste bandwidth. Use lazy loading or remove them.",
+                "score": 1,
+                "displayValue": "No hidden downloaded images",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-js-errors",
+                "title": "No JavaScript runtime errors in console",
+                "description": "Fix JavaScript errors detected at runtime. These are console.error() calls recorded during page load and indicate broken features. Unlike static linting (RWEB_0043), this check does not cover code style or syntax issues.",
+                "score": 1,
+                "displayValue": "No JavaScript runtime errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-plugins",
+                "title": "Do not use browser plugins (Flash, Silverlight, Java)",
+                "description": "Remove Flash, Silverlight and Java applet elements — these plugins are obsolete, insecure and unsupported.",
+                "score": 1,
+                "displayValue": "No browser plugins detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-unused-code",
+                "title": "Avoid render-blocking external scripts",
+                "description": "Add async or defer to external scripts to prevent blocking the critical rendering path. Render-blocking scripts delay page display and increase CPU usage unnecessarily.",
+                "score": 1,
+                "displayValue": "No render-blocking external scripts",
+                "status": "OK"
+              }
+            ]
+          }
+        },
+        {
+          "url": "http://localhost:3000/svg",
+          "rweb": {
+            "title": "Bonnes pratiques RWEB",
+            "bestPractices": [
+              {
+                "id": "rweb-no-animations",
+                "title": "RWEB_0009 - No animated elements",
+                "description": "Avoid animations and transitions to reduce CPU and battery usage. [See RWEB_0009](https://rweb.greenit.fr/en/fiches/RWEB_0009-avoid-javascriptcss-animations)",
+                "score": 1,
+                "displayValue": "No animated elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-carousel",
+                "title": "RWEB_0010 - Avoid carousels",
+                "description": "Avoid using carousel/slider libraries when possible. [See RWEB_0010](https://rweb.greenit.fr/en/fiches/RWEB_0010-limiting-the-use-of-carousels)",
+                "score": 1,
+                "displayValue": "No carousel libraries detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-title-meta",
+                "title": "RWEB_0011 - Missing title or meta description",
+                "description": "Ensure the page has a non-empty title and meta description. [See RWEB_0011](https://rweb.greenit.fr/en/fiches/RWEB_0011-relevant-page-titles-and-metadescriptions)",
+                "score": 0,
+                "displayValue": "Missing title or meta description",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-print-css",
+                "title": "RWEB_0031 - No print css implemented.",
+                "description": "A print css must be implemented to hide useless elements when printing. [See RWEB_0031](https://rweb.greenit.fr/en/fiches/RWEB_0031-provide-a-css-print)",
+                "score": 0,
+                "displayValue": "Print CSS count: 0",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-limit-fonts",
+                "title": "RWEB_0032 - Limit font families (≤ 2)",
+                "description": "Reduce the number of external font families loaded. [See RWEB_0032](https://rweb.greenit.fr/en/fiches/RWEB_0032-prefer-standard-fonts)",
+                "score": 1,
+                "displayValue": "0 external font families",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-embedded-docs",
+                "title": "RWEB_0033 - No embedded documents",
+                "description": "Avoid embedding documents (PDF, Word, etc.) directly in HTML. Use links instead. [See RWEB_0033](https://rweb.greenit.fr/en/fiches/RWEB_0033-do-not-display-documents-within-pages)",
+                "score": 1,
+                "displayValue": "No embedded documents detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-css-files",
+                "title": "RWEB_0035 - Limit CSS stylesheets (≤ 7)",
+                "description": "Keep the number of CSS files to 7 or fewer to reduce HTTP requests. [See RWEB_0035](https://rweb.greenit.fr/en/fiches/RWEB_0035-limit-the-number-of-css)",
+                "score": 1,
+                "displayValue": "0 CSS stylesheet(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-css-splitting",
+                "title": "RWEB_0036 - Split CSS by media context",
+                "description": "Split large CSS files by media type (print, mobile…) so only relevant styles are parsed. [See RWEB_0036](https://rweb.greenit.fr/en/fiches/RWEB_0036-divide-css)",
+                "score": 1,
+                "displayValue": "All large CSS files are scoped by media type",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-prefer-css",
+                "title": "RWEB_0037 - Prefer CSS over images for UI elements",
+                "description": "Replace bitmap or SVG icons inside buttons and links with CSS shapes or icon fonts to reduce HTTP requests. [See RWEB_0037](https://rweb.greenit.fr/en/fiches/RWEB_0037-use-css-instead-of-images)",
+                "score": 1,
+                "displayValue": "No icon images in buttons/links detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-bitmap-ui",
+                "title": "RWEB_0038 - Avoid bitmap images for UI elements",
+                "description": "Replace bitmap images (PNG/JPG/WebP) in headers, navs, footers and buttons with SVG or CSS. [See RWEB_0038](https://rweb.greenit.fr/en/fiches/RWEB_0038-avoid-using-raster-images-for-the-interface)",
+                "score": 1,
+                "displayValue": "No bitmap images in UI containers",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-inline-assets",
+                "title": "RWEB_0042 - Minimize inline assets",
+                "description": "Minimize the use of inline scripts and styles. [See RWEB_0042](https://rweb.greenit.fr/en/fiches/RWEB_0042-externalize-css-and-javascript)",
+                "score": 1,
+                "displayValue": "1 inline asset(s) found",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-lazy-loading",
+                "title": "RWEB_0051 - Use lazy loading for images",
+                "description": "Add loading=\"lazy\" to below-the-fold images to defer their download. [See RWEB_0051](https://rweb.greenit.fr/en/fiches/RWEB_0051-use-lazy-loading)",
+                "score": 1,
+                "displayValue": "All images use lazy loading",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-canvas",
+                "title": "RWEB_0055 - Avoid canvas elements",
+                "description": "Minimize the use of canvas elements. [See RWEB_0055](https://rweb.greenit.fr/en/fiches/RWEB_0055-limit-canvas-use)",
+                "score": 1,
+                "displayValue": "No canvas elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-social-sdk",
+                "title": "RWEB_0059 - No official social network buttons",
+                "description": "Replace official social network buttons with static links to reduce third-party requests. [See RWEB_0059](https://rweb.greenit.fr/en/fiches/RWEB_0059-replace-the-official-social-network-sharing-buttons)",
+                "score": 1,
+                "displayValue": "0 social SDK request(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-service-worker",
+                "title": "RWEB_0060 - No active Service Worker detected",
+                "description": "A Service Worker improves caching and reduces network requests. [See RWEB_0060](https://rweb.greenit.fr/en/fiches/RWEB_0060-save-bandwidth-with-service-workers)",
+                "score": 0,
+                "displayValue": "No Service Worker",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-cache-control",
+                "title": "RWEB_0075 - Use Cache-Control headers",
+                "description": "Set Cache-Control headers on HTML, CSS, JS and font resources to reduce repeated downloads. [See RWEB_0075](https://rweb.greenit.fr/en/fiches/RWEB_0075-add-expires-or-cache-control-headers)",
+                "score": 1,
+                "displayValue": "All resources have Cache-Control",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-http-compression",
+                "title": "RWEB_0076 - Text resources not compressed",
+                "description": "Enable gzip/brotli compression for HTML, CSS and JS resources. [See RWEB_0076](https://rweb.greenit.fr/en/fiches/RWEB_0076-compressing-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "0/1 text resources compressed (0%)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-minification",
+                "title": "RWEB_0077 - Unminified inline CSS/JS detected",
+                "description": "Minify inline style and script blocks to reduce page weight. [See RWEB_0077](https://rweb.greenit.fr/en/fiches/RWEB_0077-minifying-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "1 unminified inline asset(s)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-combine-assets",
+                "title": "RWEB_0078 - Combine CSS and JS files (≤2 each)",
+                "description": "Concatenate CSS and JS files to reduce HTTP requests. [See RWEB_0078](https://rweb.greenit.fr/en/fiches/RWEB_0078-combining-css-and-javascript-files)",
+                "score": 1,
+                "displayValue": "0 CSS + 0 JS files",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-cookie-on-static",
+                "title": "RWEB_0081 - No cookies on static resources",
+                "description": "Avoid sending cookies with static resources (images, CSS, JS, fonts). [See RWEB_0081](https://rweb.greenit.fr/en/fiches/RWEB_0081-host-static-resources-on-a-cookie-free-domain)",
+                "score": 1,
+                "displayValue": "No static resources with Cookie header",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-domains",
+                "title": "RWEB_0082 - Limit resource domains (≤ 5)",
+                "description": "Reduce the number of unique domains serving page resources. [See RWEB_0082](https://rweb.greenit.fr/en/fiches/RWEB_0082-limit-the-number-of-domains-serving-resources)",
+                "score": 1,
+                "displayValue": "1 unique domain(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-uses-http2",
+                "title": "RWEB_0083 - Resources served over HTTP/1",
+                "description": "Use HTTP/2 to benefit from multiplexing and header compression. [See RWEB_0083](https://rweb.greenit.fr/en/fiches/RWEB_0083-http2-over-http1)",
+                "score": 0,
+                "displayValue": "1 resource(s) on HTTP/1",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-hsts",
+                "title": "RWEB_0084 - HSTS header missing",
+                "description": "Enable HSTS (HTTP Strict-Transport-Security) header to enforce HTTPS. [See RWEB_0084](https://rweb.greenit.fr/en/fiches/RWEB_0084-favor-hsts-preload-list-over-301-redirects)",
+                "score": 0,
+                "displayValue": "HSTS header is missing",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-gif",
+                "title": "RWEB_0099 - Avoid using GIFs",
+                "description": "Avoid using GIFs for animations or images; use modern formats instead. [See RWEB_0099](https://rweb.greenit.fr/en/fiches/RWEB_0099-limit-the-use-of-animated-gif)",
+                "score": 1,
+                "displayValue": "No GIFs detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-optimize-svg",
+                "title": "RWEB_0100 - Optimize SVG files",
+                "description": "SVG files over 2048 bytes likely contain metadata or comments that can be removed. [See RWEB_0100](https://rweb.greenit.fr/en/fiches/RWEB_0100-optimize-vector-images)",
+                "score": 1,
+                "displayValue": "All SVG files appear optimized",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-autoplay",
+                "title": "RWEB_0106 - No video/audio autoplay",
+                "description": "Avoid autoplay on video and audio elements. [See RWEB_0106](https://rweb.greenit.fr/es/fiches/RWEB_0106-evitar-la-reproduccion-y-carga-automatica-de-videos-y-sonidos)",
+                "score": 1,
+                "displayValue": "0 autoplay element(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-analytics",
+                "title": "RWEB_0111 - Limit analytics tools (≤ 1)",
+                "description": "Limit analytics tools to one per page. [See RWEB_0111](https://rweb.greenit.fr/es/fiches/RWEB_0111-limitar-las-herramientas-de-analisis-y-los-datos-recopilados)",
+                "score": 1,
+                "displayValue": "0 analytics tool(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-redirects",
+                "title": "RWEB_0112 - Avoid HTTP redirects (≤ 1)",
+                "description": "Reduce HTTP redirects to avoid unnecessary round trips. [See RWEB_0112](https://rweb.greenit.fr/en/fiches/RWEB_0112-avoir-redirections)",
+                "score": 1,
+                "displayValue": "0 redirect(s)",
+                "status": "OK"
+              }
+            ]
+          },
+          "bp": {
+            "title": "Bonnes pratiques generiques d'ecoconception",
+            "bestPractices": [
+              {
+                "id": "bp-badly-sized-images",
+                "title": "Do not resize images in the browser",
+                "description": "Do not resize images using the HTML attributes height and width. This sends images in their original size, wasting bandwidth and processor power. A PNG-24 image measuring 350 x 300 px is 41 KB. If you were to resize the same image file in HTML and display it as a 70 x 60 px thumbnail, it would still be 41 KB, when in fact it should be no more than 3 KB! This means 38 KB downloaded for nothing. The best solution is to resize images using software such as Photoshop, without using HTML. When the content added by website users has no specific added value, it",
+                "score": 1,
+                "displayValue": "Found 0 resized image(s)",
+                "status": "OK"
+              },
+              {
+                "id": "bp-cookie-size",
+                "title": "Cookie size ≤ 512 bytes",
+                "description": "Keep Cookie request headers under 512 bytes to reduce HTTP overhead.",
+                "score": 1,
+                "displayValue": "No Cookie header exceeds 512 bytes",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-http-errors",
+                "title": "Avoid HTTP request errors (4xx/5xx)",
+                "description": "Fix broken resources (404, 500…) to avoid unnecessary network load and improve user experience.",
+                "score": 1,
+                "displayValue": "No HTTP errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-document-write",
+                "title": "Avoid blocking DOM write API in inline scripts",
+                "description": "Using the deprecated DOM write API blocks HTML parsing and forces a full browser re-parse. Replace it with modern DOM manipulation methods (e.g. element.insertAdjacentHTML or appendChild).",
+                "score": 1,
+                "displayValue": "No blocking DOM write API detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-hidden-images",
+                "title": "Avoid downloading images that are not displayed",
+                "description": "Images that are downloaded but hidden waste bandwidth. Use lazy loading or remove them.",
+                "score": 1,
+                "displayValue": "No hidden downloaded images",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-js-errors",
+                "title": "No JavaScript runtime errors in console",
+                "description": "Fix JavaScript errors detected at runtime. These are console.error() calls recorded during page load and indicate broken features. Unlike static linting (RWEB_0043), this check does not cover code style or syntax issues.",
+                "score": 1,
+                "displayValue": "No JavaScript runtime errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-plugins",
+                "title": "Do not use browser plugins (Flash, Silverlight, Java)",
+                "description": "Remove Flash, Silverlight and Java applet elements — these plugins are obsolete, insecure and unsupported.",
+                "score": 1,
+                "displayValue": "No browser plugins detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-unused-code",
+                "title": "Avoid render-blocking external scripts",
+                "description": "Add async or defer to external scripts to prevent blocking the critical rendering path. Render-blocking scripts delay page display and increase CPU usage unnecessarily.",
+                "score": 1,
+                "displayValue": "No render-blocking external scripts",
+                "status": "OK"
+              }
+            ]
+          }
+        },
+        {
+          "url": "http://localhost:3000/shadow-dom",
+          "rweb": {
+            "title": "Bonnes pratiques RWEB",
+            "bestPractices": [
+              {
+                "id": "rweb-no-animations",
+                "title": "RWEB_0009 - No animated elements",
+                "description": "Avoid animations and transitions to reduce CPU and battery usage. [See RWEB_0009](https://rweb.greenit.fr/en/fiches/RWEB_0009-avoid-javascriptcss-animations)",
+                "score": 1,
+                "displayValue": "No animated elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-carousel",
+                "title": "RWEB_0010 - Avoid carousels",
+                "description": "Avoid using carousel/slider libraries when possible. [See RWEB_0010](https://rweb.greenit.fr/en/fiches/RWEB_0010-limiting-the-use-of-carousels)",
+                "score": 1,
+                "displayValue": "No carousel libraries detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-title-meta",
+                "title": "RWEB_0011 - Missing title or meta description",
+                "description": "Ensure the page has a non-empty title and meta description. [See RWEB_0011](https://rweb.greenit.fr/en/fiches/RWEB_0011-relevant-page-titles-and-metadescriptions)",
+                "score": 0,
+                "displayValue": "Missing title or meta description",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-print-css",
+                "title": "RWEB_0031 - No print css implemented.",
+                "description": "A print css must be implemented to hide useless elements when printing. [See RWEB_0031](https://rweb.greenit.fr/en/fiches/RWEB_0031-provide-a-css-print)",
+                "score": 0,
+                "displayValue": "Print CSS count: 0",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-limit-fonts",
+                "title": "RWEB_0032 - Limit font families (≤ 2)",
+                "description": "Reduce the number of external font families loaded. [See RWEB_0032](https://rweb.greenit.fr/en/fiches/RWEB_0032-prefer-standard-fonts)",
+                "score": 1,
+                "displayValue": "0 external font families",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-embedded-docs",
+                "title": "RWEB_0033 - No embedded documents",
+                "description": "Avoid embedding documents (PDF, Word, etc.) directly in HTML. Use links instead. [See RWEB_0033](https://rweb.greenit.fr/en/fiches/RWEB_0033-do-not-display-documents-within-pages)",
+                "score": 1,
+                "displayValue": "No embedded documents detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-css-files",
+                "title": "RWEB_0035 - Limit CSS stylesheets (≤ 7)",
+                "description": "Keep the number of CSS files to 7 or fewer to reduce HTTP requests. [See RWEB_0035](https://rweb.greenit.fr/en/fiches/RWEB_0035-limit-the-number-of-css)",
+                "score": 1,
+                "displayValue": "0 CSS stylesheet(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-css-splitting",
+                "title": "RWEB_0036 - Split CSS by media context",
+                "description": "Split large CSS files by media type (print, mobile…) so only relevant styles are parsed. [See RWEB_0036](https://rweb.greenit.fr/en/fiches/RWEB_0036-divide-css)",
+                "score": 1,
+                "displayValue": "All large CSS files are scoped by media type",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-prefer-css",
+                "title": "RWEB_0037 - Prefer CSS over images for UI elements",
+                "description": "Replace bitmap or SVG icons inside buttons and links with CSS shapes or icon fonts to reduce HTTP requests. [See RWEB_0037](https://rweb.greenit.fr/en/fiches/RWEB_0037-use-css-instead-of-images)",
+                "score": 1,
+                "displayValue": "No icon images in buttons/links detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-bitmap-ui",
+                "title": "RWEB_0038 - Avoid bitmap images for UI elements",
+                "description": "Replace bitmap images (PNG/JPG/WebP) in headers, navs, footers and buttons with SVG or CSS. [See RWEB_0038](https://rweb.greenit.fr/en/fiches/RWEB_0038-avoid-using-raster-images-for-the-interface)",
+                "score": 1,
+                "displayValue": "No bitmap images in UI containers",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-inline-assets",
+                "title": "RWEB_0042 - Minimize inline assets",
+                "description": "Minimize the use of inline scripts and styles. [See RWEB_0042](https://rweb.greenit.fr/en/fiches/RWEB_0042-externalize-css-and-javascript)",
+                "score": 1,
+                "displayValue": "2 inline asset(s) found",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-lazy-loading",
+                "title": "RWEB_0051 - Use lazy loading for images",
+                "description": "Add loading=\"lazy\" to below-the-fold images to defer their download. [See RWEB_0051](https://rweb.greenit.fr/en/fiches/RWEB_0051-use-lazy-loading)",
+                "score": 1,
+                "displayValue": "All images use lazy loading",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-canvas",
+                "title": "RWEB_0055 - Avoid canvas elements",
+                "description": "Minimize the use of canvas elements. [See RWEB_0055](https://rweb.greenit.fr/en/fiches/RWEB_0055-limit-canvas-use)",
+                "score": 1,
+                "displayValue": "No canvas elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-social-sdk",
+                "title": "RWEB_0059 - No official social network buttons",
+                "description": "Replace official social network buttons with static links to reduce third-party requests. [See RWEB_0059](https://rweb.greenit.fr/en/fiches/RWEB_0059-replace-the-official-social-network-sharing-buttons)",
+                "score": 1,
+                "displayValue": "0 social SDK request(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-service-worker",
+                "title": "RWEB_0060 - No active Service Worker detected",
+                "description": "A Service Worker improves caching and reduces network requests. [See RWEB_0060](https://rweb.greenit.fr/en/fiches/RWEB_0060-save-bandwidth-with-service-workers)",
+                "score": 0,
+                "displayValue": "No Service Worker",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-cache-control",
+                "title": "RWEB_0075 - Use Cache-Control headers",
+                "description": "Set Cache-Control headers on HTML, CSS, JS and font resources to reduce repeated downloads. [See RWEB_0075](https://rweb.greenit.fr/en/fiches/RWEB_0075-add-expires-or-cache-control-headers)",
+                "score": 1,
+                "displayValue": "All resources have Cache-Control",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-http-compression",
+                "title": "RWEB_0076 - Text resources not compressed",
+                "description": "Enable gzip/brotli compression for HTML, CSS and JS resources. [See RWEB_0076](https://rweb.greenit.fr/en/fiches/RWEB_0076-compressing-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "0/1 text resources compressed (0%)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-minification",
+                "title": "RWEB_0077 - Unminified inline CSS/JS detected",
+                "description": "Minify inline style and script blocks to reduce page weight. [See RWEB_0077](https://rweb.greenit.fr/en/fiches/RWEB_0077-minifying-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "2 unminified inline asset(s)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-combine-assets",
+                "title": "RWEB_0078 - Combine CSS and JS files (≤2 each)",
+                "description": "Concatenate CSS and JS files to reduce HTTP requests. [See RWEB_0078](https://rweb.greenit.fr/en/fiches/RWEB_0078-combining-css-and-javascript-files)",
+                "score": 1,
+                "displayValue": "0 CSS + 0 JS files",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-cookie-on-static",
+                "title": "RWEB_0081 - No cookies on static resources",
+                "description": "Avoid sending cookies with static resources (images, CSS, JS, fonts). [See RWEB_0081](https://rweb.greenit.fr/en/fiches/RWEB_0081-host-static-resources-on-a-cookie-free-domain)",
+                "score": 1,
+                "displayValue": "No static resources with Cookie header",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-domains",
+                "title": "RWEB_0082 - Limit resource domains (≤ 5)",
+                "description": "Reduce the number of unique domains serving page resources. [See RWEB_0082](https://rweb.greenit.fr/en/fiches/RWEB_0082-limit-the-number-of-domains-serving-resources)",
+                "score": 1,
+                "displayValue": "1 unique domain(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-uses-http2",
+                "title": "RWEB_0083 - Resources served over HTTP/1",
+                "description": "Use HTTP/2 to benefit from multiplexing and header compression. [See RWEB_0083](https://rweb.greenit.fr/en/fiches/RWEB_0083-http2-over-http1)",
+                "score": 0,
+                "displayValue": "1 resource(s) on HTTP/1",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-hsts",
+                "title": "RWEB_0084 - HSTS header missing",
+                "description": "Enable HSTS (HTTP Strict-Transport-Security) header to enforce HTTPS. [See RWEB_0084](https://rweb.greenit.fr/en/fiches/RWEB_0084-favor-hsts-preload-list-over-301-redirects)",
+                "score": 0,
+                "displayValue": "HSTS header is missing",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-gif",
+                "title": "RWEB_0099 - Avoid using GIFs",
+                "description": "Avoid using GIFs for animations or images; use modern formats instead. [See RWEB_0099](https://rweb.greenit.fr/en/fiches/RWEB_0099-limit-the-use-of-animated-gif)",
+                "score": 1,
+                "displayValue": "No GIFs detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-optimize-svg",
+                "title": "RWEB_0100 - Optimize SVG files",
+                "description": "SVG files over 2048 bytes likely contain metadata or comments that can be removed. [See RWEB_0100](https://rweb.greenit.fr/en/fiches/RWEB_0100-optimize-vector-images)",
+                "score": 1,
+                "displayValue": "All SVG files appear optimized",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-autoplay",
+                "title": "RWEB_0106 - No video/audio autoplay",
+                "description": "Avoid autoplay on video and audio elements. [See RWEB_0106](https://rweb.greenit.fr/es/fiches/RWEB_0106-evitar-la-reproduccion-y-carga-automatica-de-videos-y-sonidos)",
+                "score": 1,
+                "displayValue": "0 autoplay element(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-analytics",
+                "title": "RWEB_0111 - Limit analytics tools (≤ 1)",
+                "description": "Limit analytics tools to one per page. [See RWEB_0111](https://rweb.greenit.fr/es/fiches/RWEB_0111-limitar-las-herramientas-de-analisis-y-los-datos-recopilados)",
+                "score": 1,
+                "displayValue": "0 analytics tool(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-redirects",
+                "title": "RWEB_0112 - Avoid HTTP redirects (≤ 1)",
+                "description": "Reduce HTTP redirects to avoid unnecessary round trips. [See RWEB_0112](https://rweb.greenit.fr/en/fiches/RWEB_0112-avoir-redirections)",
+                "score": 1,
+                "displayValue": "0 redirect(s)",
+                "status": "OK"
+              }
+            ]
+          },
+          "bp": {
+            "title": "Bonnes pratiques generiques d'ecoconception",
+            "bestPractices": [
+              {
+                "id": "bp-badly-sized-images",
+                "title": "Do not resize images in the browser",
+                "description": "Do not resize images using the HTML attributes height and width. This sends images in their original size, wasting bandwidth and processor power. A PNG-24 image measuring 350 x 300 px is 41 KB. If you were to resize the same image file in HTML and display it as a 70 x 60 px thumbnail, it would still be 41 KB, when in fact it should be no more than 3 KB! This means 38 KB downloaded for nothing. The best solution is to resize images using software such as Photoshop, without using HTML. When the content added by website users has no specific added value, it",
+                "score": 1,
+                "displayValue": "Found 0 resized image(s)",
+                "status": "OK"
+              },
+              {
+                "id": "bp-cookie-size",
+                "title": "Cookie size ≤ 512 bytes",
+                "description": "Keep Cookie request headers under 512 bytes to reduce HTTP overhead.",
+                "score": 1,
+                "displayValue": "No Cookie header exceeds 512 bytes",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-http-errors",
+                "title": "Avoid HTTP request errors (4xx/5xx)",
+                "description": "Fix broken resources (404, 500…) to avoid unnecessary network load and improve user experience.",
+                "score": 1,
+                "displayValue": "No HTTP errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-document-write",
+                "title": "Avoid blocking DOM write API in inline scripts",
+                "description": "Using the deprecated DOM write API blocks HTML parsing and forces a full browser re-parse. Replace it with modern DOM manipulation methods (e.g. element.insertAdjacentHTML or appendChild).",
+                "score": 1,
+                "displayValue": "No blocking DOM write API detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-hidden-images",
+                "title": "Avoid downloading images that are not displayed",
+                "description": "Images that are downloaded but hidden waste bandwidth. Use lazy loading or remove them.",
+                "score": 1,
+                "displayValue": "No hidden downloaded images",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-js-errors",
+                "title": "No JavaScript runtime errors in console",
+                "description": "Fix JavaScript errors detected at runtime. These are console.error() calls recorded during page load and indicate broken features. Unlike static linting (RWEB_0043), this check does not cover code style or syntax issues.",
+                "score": 1,
+                "displayValue": "No JavaScript runtime errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-plugins",
+                "title": "Do not use browser plugins (Flash, Silverlight, Java)",
+                "description": "Remove Flash, Silverlight and Java applet elements — these plugins are obsolete, insecure and unsupported.",
+                "score": 1,
+                "displayValue": "No browser plugins detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-unused-code",
+                "title": "Avoid render-blocking external scripts",
+                "description": "Add async or defer to external scripts to prevent blocking the critical rendering path. Render-blocking scripts delay page display and increase CPU usage unnecessarily.",
+                "score": 1,
+                "displayValue": "No render-blocking external scripts",
+                "status": "OK"
+              }
+            ]
+          }
+        },
+        {
+          "url": "http://localhost:3000/svg-shadow-dom",
+          "rweb": {
+            "title": "Bonnes pratiques RWEB",
+            "bestPractices": [
+              {
+                "id": "rweb-no-animations",
+                "title": "RWEB_0009 - No animated elements",
+                "description": "Avoid animations and transitions to reduce CPU and battery usage. [See RWEB_0009](https://rweb.greenit.fr/en/fiches/RWEB_0009-avoid-javascriptcss-animations)",
+                "score": 1,
+                "displayValue": "No animated elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-carousel",
+                "title": "RWEB_0010 - Avoid carousels",
+                "description": "Avoid using carousel/slider libraries when possible. [See RWEB_0010](https://rweb.greenit.fr/en/fiches/RWEB_0010-limiting-the-use-of-carousels)",
+                "score": 1,
+                "displayValue": "No carousel libraries detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-title-meta",
+                "title": "RWEB_0011 - Missing title or meta description",
+                "description": "Ensure the page has a non-empty title and meta description. [See RWEB_0011](https://rweb.greenit.fr/en/fiches/RWEB_0011-relevant-page-titles-and-metadescriptions)",
+                "score": 0,
+                "displayValue": "Missing title or meta description",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-print-css",
+                "title": "RWEB_0031 - No print css implemented.",
+                "description": "A print css must be implemented to hide useless elements when printing. [See RWEB_0031](https://rweb.greenit.fr/en/fiches/RWEB_0031-provide-a-css-print)",
+                "score": 0,
+                "displayValue": "Print CSS count: 0",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-limit-fonts",
+                "title": "RWEB_0032 - Limit font families (≤ 2)",
+                "description": "Reduce the number of external font families loaded. [See RWEB_0032](https://rweb.greenit.fr/en/fiches/RWEB_0032-prefer-standard-fonts)",
+                "score": 1,
+                "displayValue": "0 external font families",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-embedded-docs",
+                "title": "RWEB_0033 - No embedded documents",
+                "description": "Avoid embedding documents (PDF, Word, etc.) directly in HTML. Use links instead. [See RWEB_0033](https://rweb.greenit.fr/en/fiches/RWEB_0033-do-not-display-documents-within-pages)",
+                "score": 1,
+                "displayValue": "No embedded documents detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-css-files",
+                "title": "RWEB_0035 - Limit CSS stylesheets (≤ 7)",
+                "description": "Keep the number of CSS files to 7 or fewer to reduce HTTP requests. [See RWEB_0035](https://rweb.greenit.fr/en/fiches/RWEB_0035-limit-the-number-of-css)",
+                "score": 1,
+                "displayValue": "0 CSS stylesheet(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-css-splitting",
+                "title": "RWEB_0036 - Split CSS by media context",
+                "description": "Split large CSS files by media type (print, mobile…) so only relevant styles are parsed. [See RWEB_0036](https://rweb.greenit.fr/en/fiches/RWEB_0036-divide-css)",
+                "score": 1,
+                "displayValue": "All large CSS files are scoped by media type",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-prefer-css",
+                "title": "RWEB_0037 - Prefer CSS over images for UI elements",
+                "description": "Replace bitmap or SVG icons inside buttons and links with CSS shapes or icon fonts to reduce HTTP requests. [See RWEB_0037](https://rweb.greenit.fr/en/fiches/RWEB_0037-use-css-instead-of-images)",
+                "score": 1,
+                "displayValue": "No icon images in buttons/links detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-bitmap-ui",
+                "title": "RWEB_0038 - Avoid bitmap images for UI elements",
+                "description": "Replace bitmap images (PNG/JPG/WebP) in headers, navs, footers and buttons with SVG or CSS. [See RWEB_0038](https://rweb.greenit.fr/en/fiches/RWEB_0038-avoid-using-raster-images-for-the-interface)",
+                "score": 1,
+                "displayValue": "No bitmap images in UI containers",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-inline-assets",
+                "title": "RWEB_0042 - Minimize inline assets",
+                "description": "Minimize the use of inline scripts and styles. [See RWEB_0042](https://rweb.greenit.fr/en/fiches/RWEB_0042-externalize-css-and-javascript)",
+                "score": 1,
+                "displayValue": "2 inline asset(s) found",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-lazy-loading",
+                "title": "RWEB_0051 - Use lazy loading for images",
+                "description": "Add loading=\"lazy\" to below-the-fold images to defer their download. [See RWEB_0051](https://rweb.greenit.fr/en/fiches/RWEB_0051-use-lazy-loading)",
+                "score": 1,
+                "displayValue": "All images use lazy loading",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-canvas",
+                "title": "RWEB_0055 - Avoid canvas elements",
+                "description": "Minimize the use of canvas elements. [See RWEB_0055](https://rweb.greenit.fr/en/fiches/RWEB_0055-limit-canvas-use)",
+                "score": 1,
+                "displayValue": "No canvas elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-social-sdk",
+                "title": "RWEB_0059 - No official social network buttons",
+                "description": "Replace official social network buttons with static links to reduce third-party requests. [See RWEB_0059](https://rweb.greenit.fr/en/fiches/RWEB_0059-replace-the-official-social-network-sharing-buttons)",
+                "score": 1,
+                "displayValue": "0 social SDK request(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-service-worker",
+                "title": "RWEB_0060 - No active Service Worker detected",
+                "description": "A Service Worker improves caching and reduces network requests. [See RWEB_0060](https://rweb.greenit.fr/en/fiches/RWEB_0060-save-bandwidth-with-service-workers)",
+                "score": 0,
+                "displayValue": "No Service Worker",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-cache-control",
+                "title": "RWEB_0075 - Use Cache-Control headers",
+                "description": "Set Cache-Control headers on HTML, CSS, JS and font resources to reduce repeated downloads. [See RWEB_0075](https://rweb.greenit.fr/en/fiches/RWEB_0075-add-expires-or-cache-control-headers)",
+                "score": 1,
+                "displayValue": "All resources have Cache-Control",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-http-compression",
+                "title": "RWEB_0076 - Text resources not compressed",
+                "description": "Enable gzip/brotli compression for HTML, CSS and JS resources. [See RWEB_0076](https://rweb.greenit.fr/en/fiches/RWEB_0076-compressing-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "0/1 text resources compressed (0%)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-minification",
+                "title": "RWEB_0077 - Unminified inline CSS/JS detected",
+                "description": "Minify inline style and script blocks to reduce page weight. [See RWEB_0077](https://rweb.greenit.fr/en/fiches/RWEB_0077-minifying-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "2 unminified inline asset(s)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-combine-assets",
+                "title": "RWEB_0078 - Combine CSS and JS files (≤2 each)",
+                "description": "Concatenate CSS and JS files to reduce HTTP requests. [See RWEB_0078](https://rweb.greenit.fr/en/fiches/RWEB_0078-combining-css-and-javascript-files)",
+                "score": 1,
+                "displayValue": "0 CSS + 0 JS files",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-cookie-on-static",
+                "title": "RWEB_0081 - No cookies on static resources",
+                "description": "Avoid sending cookies with static resources (images, CSS, JS, fonts). [See RWEB_0081](https://rweb.greenit.fr/en/fiches/RWEB_0081-host-static-resources-on-a-cookie-free-domain)",
+                "score": 1,
+                "displayValue": "No static resources with Cookie header",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-domains",
+                "title": "RWEB_0082 - Limit resource domains (≤ 5)",
+                "description": "Reduce the number of unique domains serving page resources. [See RWEB_0082](https://rweb.greenit.fr/en/fiches/RWEB_0082-limit-the-number-of-domains-serving-resources)",
+                "score": 1,
+                "displayValue": "1 unique domain(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-uses-http2",
+                "title": "RWEB_0083 - Resources served over HTTP/1",
+                "description": "Use HTTP/2 to benefit from multiplexing and header compression. [See RWEB_0083](https://rweb.greenit.fr/en/fiches/RWEB_0083-http2-over-http1)",
+                "score": 0,
+                "displayValue": "1 resource(s) on HTTP/1",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-hsts",
+                "title": "RWEB_0084 - HSTS header missing",
+                "description": "Enable HSTS (HTTP Strict-Transport-Security) header to enforce HTTPS. [See RWEB_0084](https://rweb.greenit.fr/en/fiches/RWEB_0084-favor-hsts-preload-list-over-301-redirects)",
+                "score": 0,
+                "displayValue": "HSTS header is missing",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-gif",
+                "title": "RWEB_0099 - Avoid using GIFs",
+                "description": "Avoid using GIFs for animations or images; use modern formats instead. [See RWEB_0099](https://rweb.greenit.fr/en/fiches/RWEB_0099-limit-the-use-of-animated-gif)",
+                "score": 1,
+                "displayValue": "No GIFs detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-optimize-svg",
+                "title": "RWEB_0100 - Optimize SVG files",
+                "description": "SVG files over 2048 bytes likely contain metadata or comments that can be removed. [See RWEB_0100](https://rweb.greenit.fr/en/fiches/RWEB_0100-optimize-vector-images)",
+                "score": 1,
+                "displayValue": "All SVG files appear optimized",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-autoplay",
+                "title": "RWEB_0106 - No video/audio autoplay",
+                "description": "Avoid autoplay on video and audio elements. [See RWEB_0106](https://rweb.greenit.fr/es/fiches/RWEB_0106-evitar-la-reproduccion-y-carga-automatica-de-videos-y-sonidos)",
+                "score": 1,
+                "displayValue": "0 autoplay element(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-analytics",
+                "title": "RWEB_0111 - Limit analytics tools (≤ 1)",
+                "description": "Limit analytics tools to one per page. [See RWEB_0111](https://rweb.greenit.fr/es/fiches/RWEB_0111-limitar-las-herramientas-de-analisis-y-los-datos-recopilados)",
+                "score": 1,
+                "displayValue": "0 analytics tool(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-redirects",
+                "title": "RWEB_0112 - Avoid HTTP redirects (≤ 1)",
+                "description": "Reduce HTTP redirects to avoid unnecessary round trips. [See RWEB_0112](https://rweb.greenit.fr/en/fiches/RWEB_0112-avoir-redirections)",
+                "score": 1,
+                "displayValue": "0 redirect(s)",
+                "status": "OK"
+              }
+            ]
+          },
+          "bp": {
+            "title": "Bonnes pratiques generiques d'ecoconception",
+            "bestPractices": [
+              {
+                "id": "bp-badly-sized-images",
+                "title": "Do not resize images in the browser",
+                "description": "Do not resize images using the HTML attributes height and width. This sends images in their original size, wasting bandwidth and processor power. A PNG-24 image measuring 350 x 300 px is 41 KB. If you were to resize the same image file in HTML and display it as a 70 x 60 px thumbnail, it would still be 41 KB, when in fact it should be no more than 3 KB! This means 38 KB downloaded for nothing. The best solution is to resize images using software such as Photoshop, without using HTML. When the content added by website users has no specific added value, it",
+                "score": 1,
+                "displayValue": "Found 0 resized image(s)",
+                "status": "OK"
+              },
+              {
+                "id": "bp-cookie-size",
+                "title": "Cookie size ≤ 512 bytes",
+                "description": "Keep Cookie request headers under 512 bytes to reduce HTTP overhead.",
+                "score": 1,
+                "displayValue": "No Cookie header exceeds 512 bytes",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-http-errors",
+                "title": "Avoid HTTP request errors (4xx/5xx)",
+                "description": "Fix broken resources (404, 500…) to avoid unnecessary network load and improve user experience.",
+                "score": 1,
+                "displayValue": "No HTTP errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-document-write",
+                "title": "Avoid blocking DOM write API in inline scripts",
+                "description": "Using the deprecated DOM write API blocks HTML parsing and forces a full browser re-parse. Replace it with modern DOM manipulation methods (e.g. element.insertAdjacentHTML or appendChild).",
+                "score": 1,
+                "displayValue": "No blocking DOM write API detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-hidden-images",
+                "title": "Avoid downloading images that are not displayed",
+                "description": "Images that are downloaded but hidden waste bandwidth. Use lazy loading or remove them.",
+                "score": 1,
+                "displayValue": "No hidden downloaded images",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-js-errors",
+                "title": "No JavaScript runtime errors in console",
+                "description": "Fix JavaScript errors detected at runtime. These are console.error() calls recorded during page load and indicate broken features. Unlike static linting (RWEB_0043), this check does not cover code style or syntax issues.",
+                "score": 1,
+                "displayValue": "No JavaScript runtime errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-plugins",
+                "title": "Do not use browser plugins (Flash, Silverlight, Java)",
+                "description": "Remove Flash, Silverlight and Java applet elements — these plugins are obsolete, insecure and unsupported.",
+                "score": 1,
+                "displayValue": "No browser plugins detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-unused-code",
+                "title": "Avoid render-blocking external scripts",
+                "description": "Add async or defer to external scripts to prevent blocking the critical rendering path. Render-blocking scripts delay page display and increase CPU usage unnecessarily.",
+                "score": 1,
+                "displayValue": "No render-blocking external scripts",
+                "status": "OK"
+              }
+            ]
+          }
+        },
+        {
+          "url": "http://localhost:3000/complex",
+          "rweb": {
+            "title": "Bonnes pratiques RWEB",
+            "bestPractices": [
+              {
+                "id": "rweb-no-animations",
+                "title": "RWEB_0009 - No animated elements",
+                "description": "Avoid animations and transitions to reduce CPU and battery usage. [See RWEB_0009](https://rweb.greenit.fr/en/fiches/RWEB_0009-avoid-javascriptcss-animations)",
+                "score": 1,
+                "displayValue": "No animated elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-carousel",
+                "title": "RWEB_0010 - Avoid carousels",
+                "description": "Avoid using carousel/slider libraries when possible. [See RWEB_0010](https://rweb.greenit.fr/en/fiches/RWEB_0010-limiting-the-use-of-carousels)",
+                "score": 1,
+                "displayValue": "No carousel libraries detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-title-meta",
+                "title": "RWEB_0011 - Missing title or meta description",
+                "description": "Ensure the page has a non-empty title and meta description. [See RWEB_0011](https://rweb.greenit.fr/en/fiches/RWEB_0011-relevant-page-titles-and-metadescriptions)",
+                "score": 0,
+                "displayValue": "Missing title or meta description",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-print-css",
+                "title": "RWEB_0031 - No print css implemented.",
+                "description": "A print css must be implemented to hide useless elements when printing. [See RWEB_0031](https://rweb.greenit.fr/en/fiches/RWEB_0031-provide-a-css-print)",
+                "score": 0,
+                "displayValue": "Print CSS count: 0",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-limit-fonts",
+                "title": "RWEB_0032 - Limit font families (≤ 2)",
+                "description": "Reduce the number of external font families loaded. [See RWEB_0032](https://rweb.greenit.fr/en/fiches/RWEB_0032-prefer-standard-fonts)",
+                "score": 1,
+                "displayValue": "0 external font families",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-embedded-docs",
+                "title": "RWEB_0033 - No embedded documents",
+                "description": "Avoid embedding documents (PDF, Word, etc.) directly in HTML. Use links instead. [See RWEB_0033](https://rweb.greenit.fr/en/fiches/RWEB_0033-do-not-display-documents-within-pages)",
+                "score": 1,
+                "displayValue": "No embedded documents detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-css-files",
+                "title": "RWEB_0035 - Limit CSS stylesheets (≤ 7)",
+                "description": "Keep the number of CSS files to 7 or fewer to reduce HTTP requests. [See RWEB_0035](https://rweb.greenit.fr/en/fiches/RWEB_0035-limit-the-number-of-css)",
+                "score": 1,
+                "displayValue": "0 CSS stylesheet(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-css-splitting",
+                "title": "RWEB_0036 - Split CSS by media context",
+                "description": "Split large CSS files by media type (print, mobile…) so only relevant styles are parsed. [See RWEB_0036](https://rweb.greenit.fr/en/fiches/RWEB_0036-divide-css)",
+                "score": 1,
+                "displayValue": "All large CSS files are scoped by media type",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-prefer-css",
+                "title": "RWEB_0037 - Prefer CSS over images for UI elements",
+                "description": "Replace bitmap or SVG icons inside buttons and links with CSS shapes or icon fonts to reduce HTTP requests. [See RWEB_0037](https://rweb.greenit.fr/en/fiches/RWEB_0037-use-css-instead-of-images)",
+                "score": 1,
+                "displayValue": "No icon images in buttons/links detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-bitmap-ui",
+                "title": "RWEB_0038 - Avoid bitmap images for UI elements",
+                "description": "Replace bitmap images (PNG/JPG/WebP) in headers, navs, footers and buttons with SVG or CSS. [See RWEB_0038](https://rweb.greenit.fr/en/fiches/RWEB_0038-avoid-using-raster-images-for-the-interface)",
+                "score": 1,
+                "displayValue": "No bitmap images in UI containers",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-inline-assets",
+                "title": "RWEB_0042 - Minimize inline assets",
+                "description": "Minimize the use of inline scripts and styles. [See RWEB_0042](https://rweb.greenit.fr/en/fiches/RWEB_0042-externalize-css-and-javascript)",
+                "score": 1,
+                "displayValue": "1 inline asset(s) found",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-lazy-loading",
+                "title": "RWEB_0051 - Images without lazy loading detected",
+                "description": "Add loading=\"lazy\" to below-the-fold images to defer their download. [See RWEB_0051](https://rweb.greenit.fr/en/fiches/RWEB_0051-use-lazy-loading)",
+                "score": 0,
+                "displayValue": "2 image(s) without lazy loading",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-canvas",
+                "title": "RWEB_0055 - Avoid canvas elements",
+                "description": "Minimize the use of canvas elements. [See RWEB_0055](https://rweb.greenit.fr/en/fiches/RWEB_0055-limit-canvas-use)",
+                "score": 1,
+                "displayValue": "No canvas elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-social-sdk",
+                "title": "RWEB_0059 - No official social network buttons",
+                "description": "Replace official social network buttons with static links to reduce third-party requests. [See RWEB_0059](https://rweb.greenit.fr/en/fiches/RWEB_0059-replace-the-official-social-network-sharing-buttons)",
+                "score": 1,
+                "displayValue": "0 social SDK request(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-service-worker",
+                "title": "RWEB_0060 - No active Service Worker detected",
+                "description": "A Service Worker improves caching and reduces network requests. [See RWEB_0060](https://rweb.greenit.fr/en/fiches/RWEB_0060-save-bandwidth-with-service-workers)",
+                "score": 0,
+                "displayValue": "No Service Worker",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-cache-control",
+                "title": "RWEB_0075 - Use Cache-Control headers",
+                "description": "Set Cache-Control headers on HTML, CSS, JS and font resources to reduce repeated downloads. [See RWEB_0075](https://rweb.greenit.fr/en/fiches/RWEB_0075-add-expires-or-cache-control-headers)",
+                "score": 1,
+                "displayValue": "All resources have Cache-Control",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-http-compression",
+                "title": "RWEB_0076 - Text resources not compressed",
+                "description": "Enable gzip/brotli compression for HTML, CSS and JS resources. [See RWEB_0076](https://rweb.greenit.fr/en/fiches/RWEB_0076-compressing-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "0/1 text resources compressed (0%)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-minification",
+                "title": "RWEB_0077 - Unminified inline CSS/JS detected",
+                "description": "Minify inline style and script blocks to reduce page weight. [See RWEB_0077](https://rweb.greenit.fr/en/fiches/RWEB_0077-minifying-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "1 unminified inline asset(s)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-combine-assets",
+                "title": "RWEB_0078 - Combine CSS and JS files (≤2 each)",
+                "description": "Concatenate CSS and JS files to reduce HTTP requests. [See RWEB_0078](https://rweb.greenit.fr/en/fiches/RWEB_0078-combining-css-and-javascript-files)",
+                "score": 1,
+                "displayValue": "0 CSS + 0 JS files",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-cookie-on-static",
+                "title": "RWEB_0081 - No cookies on static resources",
+                "description": "Avoid sending cookies with static resources (images, CSS, JS, fonts). [See RWEB_0081](https://rweb.greenit.fr/en/fiches/RWEB_0081-host-static-resources-on-a-cookie-free-domain)",
+                "score": 1,
+                "displayValue": "No static resources with Cookie header",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-domains",
+                "title": "RWEB_0082 - Limit resource domains (≤ 5)",
+                "description": "Reduce the number of unique domains serving page resources. [See RWEB_0082](https://rweb.greenit.fr/en/fiches/RWEB_0082-limit-the-number-of-domains-serving-resources)",
+                "score": 1,
+                "displayValue": "1 unique domain(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-uses-http2",
+                "title": "RWEB_0083 - Resources served over HTTP/1",
+                "description": "Use HTTP/2 to benefit from multiplexing and header compression. [See RWEB_0083](https://rweb.greenit.fr/en/fiches/RWEB_0083-http2-over-http1)",
+                "score": 0,
+                "displayValue": "1 resource(s) on HTTP/1",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-hsts",
+                "title": "RWEB_0084 - HSTS header missing",
+                "description": "Enable HSTS (HTTP Strict-Transport-Security) header to enforce HTTPS. [See RWEB_0084](https://rweb.greenit.fr/en/fiches/RWEB_0084-favor-hsts-preload-list-over-301-redirects)",
+                "score": 0,
+                "displayValue": "HSTS header is missing",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-gif",
+                "title": "RWEB_0099 - Avoid using GIFs",
+                "description": "Avoid using GIFs for animations or images; use modern formats instead. [See RWEB_0099](https://rweb.greenit.fr/en/fiches/RWEB_0099-limit-the-use-of-animated-gif)",
+                "score": 1,
+                "displayValue": "No GIFs detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-optimize-svg",
+                "title": "RWEB_0100 - Optimize SVG files",
+                "description": "SVG files over 2048 bytes likely contain metadata or comments that can be removed. [See RWEB_0100](https://rweb.greenit.fr/en/fiches/RWEB_0100-optimize-vector-images)",
+                "score": 1,
+                "displayValue": "All SVG files appear optimized",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-autoplay",
+                "title": "RWEB_0106 - No video/audio autoplay",
+                "description": "Avoid autoplay on video and audio elements. [See RWEB_0106](https://rweb.greenit.fr/es/fiches/RWEB_0106-evitar-la-reproduccion-y-carga-automatica-de-videos-y-sonidos)",
+                "score": 1,
+                "displayValue": "0 autoplay element(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-analytics",
+                "title": "RWEB_0111 - Limit analytics tools (≤ 1)",
+                "description": "Limit analytics tools to one per page. [See RWEB_0111](https://rweb.greenit.fr/es/fiches/RWEB_0111-limitar-las-herramientas-de-analisis-y-los-datos-recopilados)",
+                "score": 1,
+                "displayValue": "0 analytics tool(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-redirects",
+                "title": "RWEB_0112 - Avoid HTTP redirects (≤ 1)",
+                "description": "Reduce HTTP redirects to avoid unnecessary round trips. [See RWEB_0112](https://rweb.greenit.fr/en/fiches/RWEB_0112-avoir-redirections)",
+                "score": 1,
+                "displayValue": "0 redirect(s)",
+                "status": "OK"
+              }
+            ]
+          },
+          "bp": {
+            "title": "Bonnes pratiques generiques d'ecoconception",
+            "bestPractices": [
+              {
+                "id": "bp-badly-sized-images",
+                "title": "Do not resize images in the browser",
+                "description": "Do not resize images using the HTML attributes height and width. This sends images in their original size, wasting bandwidth and processor power. A PNG-24 image measuring 350 x 300 px is 41 KB. If you were to resize the same image file in HTML and display it as a 70 x 60 px thumbnail, it would still be 41 KB, when in fact it should be no more than 3 KB! This means 38 KB downloaded for nothing. The best solution is to resize images using software such as Photoshop, without using HTML. When the content added by website users has no specific added value, it",
+                "score": 1,
+                "displayValue": "Found 0 resized image(s)",
+                "status": "OK"
+              },
+              {
+                "id": "bp-cookie-size",
+                "title": "Cookie size ≤ 512 bytes",
+                "description": "Keep Cookie request headers under 512 bytes to reduce HTTP overhead.",
+                "score": 1,
+                "displayValue": "No Cookie header exceeds 512 bytes",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-http-errors",
+                "title": "Avoid HTTP request errors (4xx/5xx)",
+                "description": "Fix broken resources (404, 500…) to avoid unnecessary network load and improve user experience.",
+                "score": 1,
+                "displayValue": "No HTTP errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-document-write",
+                "title": "Avoid blocking DOM write API in inline scripts",
+                "description": "Using the deprecated DOM write API blocks HTML parsing and forces a full browser re-parse. Replace it with modern DOM manipulation methods (e.g. element.insertAdjacentHTML or appendChild).",
+                "score": 1,
+                "displayValue": "No blocking DOM write API detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-hidden-images",
+                "title": "Avoid downloading images that are not displayed",
+                "description": "Images that are downloaded but hidden waste bandwidth. Use lazy loading or remove them.",
+                "score": 1,
+                "displayValue": "No hidden downloaded images",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-js-errors",
+                "title": "No JavaScript runtime errors in console",
+                "description": "Fix JavaScript errors detected at runtime. These are console.error() calls recorded during page load and indicate broken features. Unlike static linting (RWEB_0043), this check does not cover code style or syntax issues.",
+                "score": 1,
+                "displayValue": "No JavaScript runtime errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-plugins",
+                "title": "Do not use browser plugins (Flash, Silverlight, Java)",
+                "description": "Remove Flash, Silverlight and Java applet elements — these plugins are obsolete, insecure and unsupported.",
+                "score": 1,
+                "displayValue": "No browser plugins detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-unused-code",
+                "title": "Avoid render-blocking external scripts",
+                "description": "Add async or defer to external scripts to prevent blocking the critical rendering path. Render-blocking scripts delay page display and increase CPU usage unnecessarily.",
+                "score": 1,
+                "displayValue": "No render-blocking external scripts",
+                "status": "OK"
+              }
+            ]
+          }
+        },
+        {
+          "url": "http://localhost:3000/heavy",
+          "rweb": {
+            "title": "Bonnes pratiques RWEB",
+            "bestPractices": [
+              {
+                "id": "rweb-no-animations",
+                "title": "RWEB_0009 - No animated elements",
+                "description": "Avoid animations and transitions to reduce CPU and battery usage. [See RWEB_0009](https://rweb.greenit.fr/en/fiches/RWEB_0009-avoid-javascriptcss-animations)",
+                "score": 1,
+                "displayValue": "No animated elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-carousel",
+                "title": "RWEB_0010 - Avoid carousels",
+                "description": "Avoid using carousel/slider libraries when possible. [See RWEB_0010](https://rweb.greenit.fr/en/fiches/RWEB_0010-limiting-the-use-of-carousels)",
+                "score": 1,
+                "displayValue": "No carousel libraries detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-title-meta",
+                "title": "RWEB_0011 - Missing title or meta description",
+                "description": "Ensure the page has a non-empty title and meta description. [See RWEB_0011](https://rweb.greenit.fr/en/fiches/RWEB_0011-relevant-page-titles-and-metadescriptions)",
+                "score": 0,
+                "displayValue": "Missing title or meta description",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-print-css",
+                "title": "RWEB_0031 - No print css implemented.",
+                "description": "A print css must be implemented to hide useless elements when printing. [See RWEB_0031](https://rweb.greenit.fr/en/fiches/RWEB_0031-provide-a-css-print)",
+                "score": 0,
+                "displayValue": "Print CSS count: 0",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-limit-fonts",
+                "title": "RWEB_0032 - Limit font families (≤ 2)",
+                "description": "Reduce the number of external font families loaded. [See RWEB_0032](https://rweb.greenit.fr/en/fiches/RWEB_0032-prefer-standard-fonts)",
+                "score": 1,
+                "displayValue": "0 external font families",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-embedded-docs",
+                "title": "RWEB_0033 - No embedded documents",
+                "description": "Avoid embedding documents (PDF, Word, etc.) directly in HTML. Use links instead. [See RWEB_0033](https://rweb.greenit.fr/en/fiches/RWEB_0033-do-not-display-documents-within-pages)",
+                "score": 1,
+                "displayValue": "No embedded documents detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-css-files",
+                "title": "RWEB_0035 - Limit CSS stylesheets (≤ 7)",
+                "description": "Keep the number of CSS files to 7 or fewer to reduce HTTP requests. [See RWEB_0035](https://rweb.greenit.fr/en/fiches/RWEB_0035-limit-the-number-of-css)",
+                "score": 1,
+                "displayValue": "0 CSS stylesheet(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-css-splitting",
+                "title": "RWEB_0036 - Split CSS by media context",
+                "description": "Split large CSS files by media type (print, mobile…) so only relevant styles are parsed. [See RWEB_0036](https://rweb.greenit.fr/en/fiches/RWEB_0036-divide-css)",
+                "score": 1,
+                "displayValue": "All large CSS files are scoped by media type",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-prefer-css",
+                "title": "RWEB_0037 - Prefer CSS over images for UI elements",
+                "description": "Replace bitmap or SVG icons inside buttons and links with CSS shapes or icon fonts to reduce HTTP requests. [See RWEB_0037](https://rweb.greenit.fr/en/fiches/RWEB_0037-use-css-instead-of-images)",
+                "score": 1,
+                "displayValue": "No icon images in buttons/links detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-bitmap-ui",
+                "title": "RWEB_0038 - Avoid bitmap images for UI elements",
+                "description": "Replace bitmap images (PNG/JPG/WebP) in headers, navs, footers and buttons with SVG or CSS. [See RWEB_0038](https://rweb.greenit.fr/en/fiches/RWEB_0038-avoid-using-raster-images-for-the-interface)",
+                "score": 1,
+                "displayValue": "No bitmap images in UI containers",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-inline-assets",
+                "title": "RWEB_0042 - Minimize inline assets",
+                "description": "Minimize the use of inline scripts and styles. [See RWEB_0042](https://rweb.greenit.fr/en/fiches/RWEB_0042-externalize-css-and-javascript)",
+                "score": 1,
+                "displayValue": "1 inline asset(s) found",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-lazy-loading",
+                "title": "RWEB_0051 - Use lazy loading for images",
+                "description": "Add loading=\"lazy\" to below-the-fold images to defer their download. [See RWEB_0051](https://rweb.greenit.fr/en/fiches/RWEB_0051-use-lazy-loading)",
+                "score": 1,
+                "displayValue": "All images use lazy loading",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-canvas",
+                "title": "RWEB_0055 - Avoid canvas elements",
+                "description": "Minimize the use of canvas elements. [See RWEB_0055](https://rweb.greenit.fr/en/fiches/RWEB_0055-limit-canvas-use)",
+                "score": 1,
+                "displayValue": "No canvas elements",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-social-sdk",
+                "title": "RWEB_0059 - No official social network buttons",
+                "description": "Replace official social network buttons with static links to reduce third-party requests. [See RWEB_0059](https://rweb.greenit.fr/en/fiches/RWEB_0059-replace-the-official-social-network-sharing-buttons)",
+                "score": 1,
+                "displayValue": "0 social SDK request(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-service-worker",
+                "title": "RWEB_0060 - No active Service Worker detected",
+                "description": "A Service Worker improves caching and reduces network requests. [See RWEB_0060](https://rweb.greenit.fr/en/fiches/RWEB_0060-save-bandwidth-with-service-workers)",
+                "score": 0,
+                "displayValue": "No Service Worker",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-cache-control",
+                "title": "RWEB_0075 - Use Cache-Control headers",
+                "description": "Set Cache-Control headers on HTML, CSS, JS and font resources to reduce repeated downloads. [See RWEB_0075](https://rweb.greenit.fr/en/fiches/RWEB_0075-add-expires-or-cache-control-headers)",
+                "score": 1,
+                "displayValue": "All resources have Cache-Control",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-http-compression",
+                "title": "RWEB_0076 - Text resources not compressed",
+                "description": "Enable gzip/brotli compression for HTML, CSS and JS resources. [See RWEB_0076](https://rweb.greenit.fr/en/fiches/RWEB_0076-compressing-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "0/1 text resources compressed (0%)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-minification",
+                "title": "RWEB_0077 - Unminified inline CSS/JS detected",
+                "description": "Minify inline style and script blocks to reduce page weight. [See RWEB_0077](https://rweb.greenit.fr/en/fiches/RWEB_0077-minifying-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "1 unminified inline asset(s)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-combine-assets",
+                "title": "RWEB_0078 - Combine CSS and JS files (≤2 each)",
+                "description": "Concatenate CSS and JS files to reduce HTTP requests. [See RWEB_0078](https://rweb.greenit.fr/en/fiches/RWEB_0078-combining-css-and-javascript-files)",
+                "score": 1,
+                "displayValue": "0 CSS + 0 JS files",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-cookie-on-static",
+                "title": "RWEB_0081 - No cookies on static resources",
+                "description": "Avoid sending cookies with static resources (images, CSS, JS, fonts). [See RWEB_0081](https://rweb.greenit.fr/en/fiches/RWEB_0081-host-static-resources-on-a-cookie-free-domain)",
+                "score": 1,
+                "displayValue": "No static resources with Cookie header",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-domains",
+                "title": "RWEB_0082 - Limit resource domains (≤ 5)",
+                "description": "Reduce the number of unique domains serving page resources. [See RWEB_0082](https://rweb.greenit.fr/en/fiches/RWEB_0082-limit-the-number-of-domains-serving-resources)",
+                "score": 1,
+                "displayValue": "1 unique domain(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-uses-http2",
+                "title": "RWEB_0083 - Resources served over HTTP/1",
+                "description": "Use HTTP/2 to benefit from multiplexing and header compression. [See RWEB_0083](https://rweb.greenit.fr/en/fiches/RWEB_0083-http2-over-http1)",
+                "score": 0,
+                "displayValue": "1 resource(s) on HTTP/1",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-hsts",
+                "title": "RWEB_0084 - HSTS header missing",
+                "description": "Enable HSTS (HTTP Strict-Transport-Security) header to enforce HTTPS. [See RWEB_0084](https://rweb.greenit.fr/en/fiches/RWEB_0084-favor-hsts-preload-list-over-301-redirects)",
+                "score": 0,
+                "displayValue": "HSTS header is missing",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-gif",
+                "title": "RWEB_0099 - Avoid using GIFs",
+                "description": "Avoid using GIFs for animations or images; use modern formats instead. [See RWEB_0099](https://rweb.greenit.fr/en/fiches/RWEB_0099-limit-the-use-of-animated-gif)",
+                "score": 1,
+                "displayValue": "No GIFs detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-optimize-svg",
+                "title": "RWEB_0100 - Optimize SVG files",
+                "description": "SVG files over 2048 bytes likely contain metadata or comments that can be removed. [See RWEB_0100](https://rweb.greenit.fr/en/fiches/RWEB_0100-optimize-vector-images)",
+                "score": 1,
+                "displayValue": "All SVG files appear optimized",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-autoplay",
+                "title": "RWEB_0106 - No video/audio autoplay",
+                "description": "Avoid autoplay on video and audio elements. [See RWEB_0106](https://rweb.greenit.fr/es/fiches/RWEB_0106-evitar-la-reproduccion-y-carga-automatica-de-videos-y-sonidos)",
+                "score": 1,
+                "displayValue": "0 autoplay element(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-analytics",
+                "title": "RWEB_0111 - Limit analytics tools (≤ 1)",
+                "description": "Limit analytics tools to one per page. [See RWEB_0111](https://rweb.greenit.fr/es/fiches/RWEB_0111-limitar-las-herramientas-de-analisis-y-los-datos-recopilados)",
+                "score": 1,
+                "displayValue": "0 analytics tool(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-redirects",
+                "title": "RWEB_0112 - Avoid HTTP redirects (≤ 1)",
+                "description": "Reduce HTTP redirects to avoid unnecessary round trips. [See RWEB_0112](https://rweb.greenit.fr/en/fiches/RWEB_0112-avoir-redirections)",
+                "score": 1,
+                "displayValue": "0 redirect(s)",
+                "status": "OK"
+              }
+            ]
+          },
+          "bp": {
+            "title": "Bonnes pratiques generiques d'ecoconception",
+            "bestPractices": [
+              {
+                "id": "bp-badly-sized-images",
+                "title": "Do not resize images in the browser",
+                "description": "Do not resize images using the HTML attributes height and width. This sends images in their original size, wasting bandwidth and processor power. A PNG-24 image measuring 350 x 300 px is 41 KB. If you were to resize the same image file in HTML and display it as a 70 x 60 px thumbnail, it would still be 41 KB, when in fact it should be no more than 3 KB! This means 38 KB downloaded for nothing. The best solution is to resize images using software such as Photoshop, without using HTML. When the content added by website users has no specific added value, it",
+                "score": 1,
+                "displayValue": "Found 0 resized image(s)",
+                "status": "OK"
+              },
+              {
+                "id": "bp-cookie-size",
+                "title": "Cookie size ≤ 512 bytes",
+                "description": "Keep Cookie request headers under 512 bytes to reduce HTTP overhead.",
+                "score": 1,
+                "displayValue": "No Cookie header exceeds 512 bytes",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-http-errors",
+                "title": "Avoid HTTP request errors (4xx/5xx)",
+                "description": "Fix broken resources (404, 500…) to avoid unnecessary network load and improve user experience.",
+                "score": 1,
+                "displayValue": "No HTTP errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-document-write",
+                "title": "Avoid blocking DOM write API in inline scripts",
+                "description": "Using the deprecated DOM write API blocks HTML parsing and forces a full browser re-parse. Replace it with modern DOM manipulation methods (e.g. element.insertAdjacentHTML or appendChild).",
+                "score": 1,
+                "displayValue": "No blocking DOM write API detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-hidden-images",
+                "title": "Avoid downloading images that are not displayed",
+                "description": "Images that are downloaded but hidden waste bandwidth. Use lazy loading or remove them.",
+                "score": 1,
+                "displayValue": "No hidden downloaded images",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-js-errors",
+                "title": "No JavaScript runtime errors in console",
+                "description": "Fix JavaScript errors detected at runtime. These are console.error() calls recorded during page load and indicate broken features. Unlike static linting (RWEB_0043), this check does not cover code style or syntax issues.",
+                "score": 1,
+                "displayValue": "No JavaScript runtime errors",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-plugins",
+                "title": "Do not use browser plugins (Flash, Silverlight, Java)",
+                "description": "Remove Flash, Silverlight and Java applet elements — these plugins are obsolete, insecure and unsupported.",
+                "score": 1,
+                "displayValue": "No browser plugins detected",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-unused-code",
+                "title": "Avoid render-blocking external scripts",
+                "description": "Add async or defer to external scripts to prevent blocking the critical rendering path. Render-blocking scripts delay page display and increase CPU usage unnecessarily.",
+                "score": 1,
+                "displayValue": "No render-blocking external scripts",
+                "status": "OK"
+              }
+            ]
+          }
+        },
+        {
+          "url": "http://localhost:3000/bp-violations",
+          "rweb": {
+            "title": "Bonnes pratiques RWEB",
+            "bestPractices": [
+              {
+                "id": "rweb-no-animations",
+                "title": "RWEB_0009 - Animated elements detected",
+                "description": "Avoid animations and transitions to reduce CPU and battery usage. [See RWEB_0009](https://rweb.greenit.fr/en/fiches/RWEB_0009-avoid-javascriptcss-animations)",
+                "score": 0,
+                "displayValue": "1 animated element(s) found",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-carousel",
+                "title": "RWEB_0010 - Avoid carousels",
+                "description": "Avoid using carousel/slider libraries when possible. [See RWEB_0010](https://rweb.greenit.fr/en/fiches/RWEB_0010-limiting-the-use-of-carousels)",
+                "score": 1,
+                "displayValue": "No carousel libraries detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-title-meta",
+                "title": "RWEB_0011 - Missing title or meta description",
+                "description": "Ensure the page has a non-empty title and meta description. [See RWEB_0011](https://rweb.greenit.fr/en/fiches/RWEB_0011-relevant-page-titles-and-metadescriptions)",
+                "score": 0,
+                "displayValue": "Missing title or meta description",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-print-css",
+                "title": "RWEB_0031 - No print css implemented.",
+                "description": "A print css must be implemented to hide useless elements when printing. [See RWEB_0031](https://rweb.greenit.fr/en/fiches/RWEB_0031-provide-a-css-print)",
+                "score": 0,
+                "displayValue": "Print CSS count: 0",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-limit-fonts",
+                "title": "RWEB_0032 - Limit font families (≤ 2)",
+                "description": "Reduce the number of external font families loaded. [See RWEB_0032](https://rweb.greenit.fr/en/fiches/RWEB_0032-prefer-standard-fonts)",
+                "score": 1,
+                "displayValue": "0 external font families",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-embedded-docs",
+                "title": "RWEB_0033 - Embedded documents detected",
+                "description": "Avoid embedding documents (PDF, Word, etc.) directly in HTML. Use links instead. [See RWEB_0033](https://rweb.greenit.fr/en/fiches/RWEB_0033-do-not-display-documents-within-pages)",
+                "score": 0,
+                "displayValue": "2 embedded document(s) found",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-css-splitting",
+                "title": "RWEB_0036 - Large CSS files without media targeting detected",
+                "description": "Split large CSS files by media type (print, mobile…) so only relevant styles are parsed. [See RWEB_0036](https://rweb.greenit.fr/en/fiches/RWEB_0036-divide-css)",
+                "score": 0,
+                "displayValue": "2 large CSS file(s) without media targeting",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-prefer-css",
+                "title": "RWEB_0037 - Images used for UI icons (prefer CSS)",
+                "description": "Replace bitmap or SVG icons inside buttons and links with CSS shapes or icon fonts to reduce HTTP requests. [See RWEB_0037](https://rweb.greenit.fr/en/fiches/RWEB_0037-use-css-instead-of-images)",
+                "score": 0,
+                "displayValue": "1 image(s) used as UI icons",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-bitmap-ui",
+                "title": "RWEB_0038 - Bitmap images in UI containers detected",
+                "description": "Replace bitmap images (PNG/JPG/WebP) in headers, navs, footers and buttons with SVG or CSS. [See RWEB_0038](https://rweb.greenit.fr/en/fiches/RWEB_0038-avoid-using-raster-images-for-the-interface)",
+                "score": 0,
+                "displayValue": "2 bitmap image(s) in UI containers",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-inline-assets",
+                "title": "RWEB_0042 - Inline assets detected",
+                "description": "Minimize the use of inline scripts and styles. [See RWEB_0042](https://rweb.greenit.fr/en/fiches/RWEB_0042-externalize-css-and-javascript)",
+                "score": 0,
+                "displayValue": "7 inline asset(s) found",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-lazy-loading",
+                "title": "RWEB_0051 - Images without lazy loading detected",
+                "description": "Add loading=\"lazy\" to below-the-fold images to defer their download. [See RWEB_0051](https://rweb.greenit.fr/en/fiches/RWEB_0051-use-lazy-loading)",
+                "score": 0,
+                "displayValue": "6 image(s) without lazy loading",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-canvas",
+                "title": "RWEB_0055 - Canvas elements detected",
+                "description": "Minimize the use of canvas elements. [See RWEB_0055](https://rweb.greenit.fr/en/fiches/RWEB_0055-limit-canvas-use)",
+                "score": 0,
+                "displayValue": "1 canvas element(s) found",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-social-sdk",
+                "title": "RWEB_0059 - No official social network buttons",
+                "description": "Replace official social network buttons with static links to reduce third-party requests. [See RWEB_0059](https://rweb.greenit.fr/en/fiches/RWEB_0059-replace-the-official-social-network-sharing-buttons)",
+                "score": 1,
+                "displayValue": "0 social SDK request(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-service-worker",
+                "title": "RWEB_0060 - No active Service Worker detected",
+                "description": "A Service Worker improves caching and reduces network requests. [See RWEB_0060](https://rweb.greenit.fr/en/fiches/RWEB_0060-save-bandwidth-with-service-workers)",
+                "score": 0,
+                "displayValue": "No Service Worker",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-cache-control",
+                "title": "RWEB_0075 - Resources missing Cache-Control header",
+                "description": "Set Cache-Control headers on HTML, CSS, JS and font resources to reduce repeated downloads. [See RWEB_0075](https://rweb.greenit.fr/en/fiches/RWEB_0075-add-expires-or-cache-control-headers)",
+                "score": 0,
+                "displayValue": "1 resource(s) missing Cache-Control",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-http-compression",
+                "title": "RWEB_0076 - Text resources not compressed",
+                "description": "Enable gzip/brotli compression for HTML, CSS and JS resources. [See RWEB_0076](https://rweb.greenit.fr/en/fiches/RWEB_0076-compressing-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "0/13 text resources compressed (0%)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-minification",
+                "title": "RWEB_0077 - Unminified inline CSS/JS detected",
+                "description": "Minify inline style and script blocks to reduce page weight. [See RWEB_0077](https://rweb.greenit.fr/en/fiches/RWEB_0077-minifying-text-files-css-js-html-and-svg)",
+                "score": 0,
+                "displayValue": "4 unminified inline asset(s)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-combine-assets",
+                "title": "RWEB_0078 - Too many separate CSS/JS files",
+                "description": "Concatenate CSS and JS files to reduce HTTP requests. [See RWEB_0078](https://rweb.greenit.fr/en/fiches/RWEB_0078-combining-css-and-javascript-files)",
+                "score": 0,
+                "displayValue": "9 CSS + 3 JS files",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-cookie-on-static",
+                "title": "RWEB_0081 - No cookies on static resources",
+                "description": "Avoid sending cookies with static resources (images, CSS, JS, fonts). [See RWEB_0081](https://rweb.greenit.fr/en/fiches/RWEB_0081-host-static-resources-on-a-cookie-free-domain)",
+                "score": 1,
+                "displayValue": "No static resources with Cookie header",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-limit-domains",
+                "title": "RWEB_0082 - Limit resource domains (≤ 5)",
+                "description": "Reduce the number of unique domains serving page resources. [See RWEB_0082](https://rweb.greenit.fr/en/fiches/RWEB_0082-limit-the-number-of-domains-serving-resources)",
+                "score": 1,
+                "displayValue": "1 unique domain(s)",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-uses-http2",
+                "title": "RWEB_0083 - Resources served over HTTP/1",
+                "description": "Use HTTP/2 to benefit from multiplexing and header compression. [See RWEB_0083](https://rweb.greenit.fr/en/fiches/RWEB_0083-http2-over-http1)",
+                "score": 0,
+                "displayValue": "18 resource(s) on HTTP/1",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-hsts",
+                "title": "RWEB_0084 - HSTS header missing",
+                "description": "Enable HSTS (HTTP Strict-Transport-Security) header to enforce HTTPS. [See RWEB_0084](https://rweb.greenit.fr/en/fiches/RWEB_0084-favor-hsts-preload-list-over-301-redirects)",
+                "score": 0,
+                "displayValue": "HSTS header is missing",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-no-gif",
+                "title": "RWEB_0099 - GIFs detected",
+                "description": "Avoid using GIFs for animations or images; use modern formats instead. [See RWEB_0099](https://rweb.greenit.fr/en/fiches/RWEB_0099-limit-the-use-of-animated-gif)",
+                "score": 0,
+                "displayValue": "3 GIF(s) detected",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-optimize-svg",
+                "title": "RWEB_0100 - Optimize SVG files",
+                "description": "SVG files over 2048 bytes likely contain metadata or comments that can be removed. [See RWEB_0100](https://rweb.greenit.fr/en/fiches/RWEB_0100-optimize-vector-images)",
+                "score": 1,
+                "displayValue": "All SVG files appear optimized",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-autoplay",
+                "title": "RWEB_0106 - Autoplay video/audio detected",
+                "description": "Avoid autoplay on video and audio elements. [See RWEB_0106](https://rweb.greenit.fr/es/fiches/RWEB_0106-evitar-la-reproduccion-y-carga-automatica-de-videos-y-sonidos)",
+                "score": 0,
+                "displayValue": "1 autoplay element(s)",
+                "status": "KO"
+              },
+              {
+                "id": "rweb-limit-analytics",
+                "title": "RWEB_0111 - Limit analytics tools (≤ 1)",
+                "description": "Limit analytics tools to one per page. [See RWEB_0111](https://rweb.greenit.fr/es/fiches/RWEB_0111-limitar-las-herramientas-de-analisis-y-los-datos-recopilados)",
+                "score": 1,
+                "displayValue": "0 analytics tool(s) detected",
+                "status": "OK"
+              },
+              {
+                "id": "rweb-no-redirects",
+                "title": "RWEB_0112 - Avoid HTTP redirects (≤ 1)",
+                "description": "Reduce HTTP redirects to avoid unnecessary round trips. [See RWEB_0112](https://rweb.greenit.fr/en/fiches/RWEB_0112-avoir-redirections)",
+                "score": 1,
+                "displayValue": "0 redirect(s)",
+                "status": "OK"
+              }
+            ]
+          },
+          "bp": {
+            "title": "Bonnes pratiques generiques d'ecoconception",
+            "bestPractices": [
+              {
+                "id": "bp-badly-sized-images",
+                "title": "Do not resize images in the browser",
+                "description": "Do not resize images using the HTML attributes height and width. This sends images in their original size, wasting bandwidth and processor power. A PNG-24 image measuring 350 x 300 px is 41 KB. If you were to resize the same image file in HTML and display it as a 70 x 60 px thumbnail, it would still be 41 KB, when in fact it should be no more than 3 KB! This means 38 KB downloaded for nothing. The best solution is to resize images using software such as Photoshop, without using HTML. When the content added by website users has no specific added value, it",
+                "score": 1,
+                "displayValue": "Found 0 resized image(s)",
+                "status": "OK"
+              },
+              {
+                "id": "bp-cookie-size",
+                "title": "Cookie size ≤ 512 bytes",
+                "description": "Keep Cookie request headers under 512 bytes to reduce HTTP overhead.",
+                "score": 1,
+                "displayValue": "No Cookie header exceeds 512 bytes",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-http-errors",
+                "title": "HTTP request errors detected (4xx/5xx)",
+                "description": "Fix broken resources (404, 500…) to avoid unnecessary network load and improve user experience.",
+                "score": 0,
+                "displayValue": "5 HTTP error(s) detected",
+                "status": "KO"
+              },
+              {
+                "id": "bp-no-document-write",
+                "title": "Blocking DOM write API detected in inline scripts",
+                "description": "Using the deprecated DOM write API blocks HTML parsing and forces a full browser re-parse. Replace it with modern DOM manipulation methods (e.g. element.insertAdjacentHTML or appendChild).",
+                "score": 0,
+                "displayValue": "1 blocking DOM write API call(s) in inline scripts",
+                "status": "KO"
+              },
+              {
+                "id": "bp-no-hidden-images",
+                "title": "Avoid downloading images that are not displayed",
+                "description": "Images that are downloaded but hidden waste bandwidth. Use lazy loading or remove them.",
+                "score": 1,
+                "displayValue": "No hidden downloaded images",
+                "status": "OK"
+              },
+              {
+                "id": "bp-no-js-errors",
+                "title": "JavaScript runtime errors detected in console",
+                "description": "Fix JavaScript errors detected at runtime. These are console.error() calls recorded during page load and indicate broken features. Unlike static linting (RWEB_0043), this check does not cover code style or syntax issues.",
+                "score": 0,
+                "displayValue": "6 JavaScript runtime error(s)",
+                "status": "KO"
+              },
+              {
+                "id": "bp-no-plugins",
+                "title": "Browser plugin detected (Flash, Silverlight, Java)",
+                "description": "Remove Flash, Silverlight and Java applet elements — these plugins are obsolete, insecure and unsupported.",
+                "score": 0,
+                "displayValue": "1 browser plugin(s) detected",
+                "status": "KO"
+              },
+              {
+                "id": "bp-no-unused-code",
+                "title": "Render-blocking external scripts detected",
+                "description": "Add async or defer to external scripts to prevent blocking the critical rendering path. Render-blocking scripts delay page display and increase CPU usage unnecessarily.",
+                "score": 0,
+                "displayValue": "3 render-blocking external script(s)",
+                "status": "KO"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/libs/ecoindex-lh-courses/package.json
+++ b/libs/ecoindex-lh-courses/package.json
@@ -81,11 +81,11 @@
   "dependencies": {
     "@puppeteer/browsers": "3.0.4",
     "ecoindex": "^2.0.1",
-    "lighthouse": "13.3.0",
+    "lighthouse": "13.4.1",
     "lighthouse-plugin-ecoindex-core": "workspace:*",
     "log-symbols": "4.1.0",
-    "puppeteer": "25.1.0",
-    "puppeteer-core": "25.1.0",
+    "puppeteer": "25.5.0",
+    "puppeteer-core": "25.5.0",
     "slugify": "^1.6.6"
   },
   "devDependencies": {

--- a/libs/ecoindex-lh-courses/src/converters.ts
+++ b/libs/ecoindex-lh-courses/src/converters.ts
@@ -158,9 +158,12 @@ function convertBestPracticeAudit(
   const bestPractice = Object.fromEntries(
     Object.entries(audit).filter(
       ([key]) =>
-        !['details', 'scoreDisplayMode', 'numericValue', 'numericUnit'].includes(
-          key,
-        ),
+        ![
+          'details',
+          'scoreDisplayMode',
+          'numericValue',
+          'numericUnit',
+        ].includes(key),
     ),
   )
 

--- a/libs/ecoindex-lh-courses/src/converters.ts
+++ b/libs/ecoindex-lh-courses/src/converters.ts
@@ -155,8 +155,14 @@ function convertBestPracticeAudit(
 ): BestPracticeAudit | undefined {
   if (audit.score !== 0 && audit.score !== 1) return undefined
 
-  const { details, scoreDisplayMode, numericValue, numericUnit, ...bestPractice } =
-    audit
+  const bestPractice = Object.fromEntries(
+    Object.entries(audit).filter(
+      ([key]) =>
+        !['details', 'scoreDisplayMode', 'numericValue', 'numericUnit'].includes(
+          key,
+        ),
+    ),
+  )
 
   return {
     ...bestPractice,

--- a/libs/ecoindex-lh-courses/src/converters.ts
+++ b/libs/ecoindex-lh-courses/src/converters.ts
@@ -1,7 +1,14 @@
 import type * as LH from 'lighthouse/types/lh.js'
 import * as path from 'node:path'
 
-import { Course, CourseResultConverted, Flows, Summary } from './types/index.js'
+import {
+  BestPracticeAudit,
+  BestPracticesPage,
+  Course,
+  CourseResultConverted,
+  Flows,
+  Summary,
+} from './types/index.js'
 
 import { getEcoIndexGrade } from 'ecoindex'
 
@@ -143,8 +150,46 @@ function convertPagesResults(lhr: LH.Result): Summary {
   }
 }
 
+function convertBestPracticeAudit(
+  audit: LH.Result['audits'][string],
+): BestPracticeAudit | undefined {
+  if (audit.score !== 0 && audit.score !== 1) return undefined
+
+  const { details, scoreDisplayMode, numericValue, numericUnit, ...bestPractice } =
+    audit
+
+  return {
+    ...bestPractice,
+    status: audit.score === 1 ? 'OK' : 'KO',
+  }
+}
+
+function convertBestPracticesPageResults(lhr: LH.Result): BestPracticesPage {
+  const page: BestPracticesPage = {
+    url: lhr.requestedUrl,
+    rweb: {
+      title: 'Bonnes pratiques RWEB',
+      bestPractices: [],
+    },
+    bp: {
+      title: "Bonnes pratiques generiques d'ecoconception",
+      bestPractices: [],
+    },
+  }
+
+  for (const [auditId, audit] of Object.entries(lhr.audits)) {
+    const bestPractice = convertBestPracticeAudit(audit)
+    if (!bestPractice) continue
+
+    if (auditId.startsWith('rweb-')) page.rweb.bestPractices.push(bestPractice)
+    if (auditId.startsWith('bp-')) page.bp.bestPractices.push(bestPractice)
+  }
+
+  return page
+}
+
 function cleanPath(thePath: string) {
   return thePath.replace(/\//gm, path.sep)
 }
 
-export { cleanPath, convertCourseResults }
+export { cleanPath, convertBestPracticesPageResults, convertCourseResults }

--- a/libs/ecoindex-lh-courses/src/printer.ts
+++ b/libs/ecoindex-lh-courses/src/printer.ts
@@ -3,10 +3,18 @@ import type * as LH from 'lighthouse/types/lh.js'
 import fs, { writeFileSync } from 'fs'
 import path, { dirname } from 'path'
 import { getEnvStatementsObj, slugify } from './commands.js'
-import { cleanPath, convertCourseResults } from './converters.js'
 import {
+  cleanPath,
+  convertBestPracticesPageResults,
+  convertCourseResults,
+} from './converters.js'
+import {
+  BestPracticeAudit,
+  BestPracticeSection,
+  BestPracticesCourseReport,
   CliFlags,
   Course,
+  Flows,
   PrinterOutput,
   StatementsReport,
   SummaryToPrint,
@@ -19,6 +27,7 @@ import { renderHtml, renderMarkdown } from './templates/fr_FR/index.js'
 
 const SEPARATOR = '\n---------------------------------\n'
 const _dirname = fileURLToPath(dirname(import.meta.url))
+type FlowStep = Flows['steps'][number]
 
 /**
  * Prepare folder and naming files.
@@ -271,6 +280,163 @@ async function printEnvStatementDocuments(cliFlags: CliFlags) {
   console.log(SEPARATOR)
 }
 
+function formatMarkdownValue(value: unknown): string {
+  return typeof value === 'object' && value !== null
+    ? JSON.stringify(value)
+    : String(value)
+}
+
+function renderDetails(details: unknown): string {
+  if (typeof details !== 'object' || details === null) {
+    return `\`\`\`json\n${JSON.stringify(details, null, 2)}\n\`\`\``
+  }
+
+  const detail = details as {
+    type?: string
+    headings?: Array<{ text?: string; key?: string }>
+    items?: unknown[]
+  }
+
+  if (
+    (detail.type === 'table' || detail.type === 'opportunity') &&
+    detail.headings &&
+    detail.items
+  ) {
+    const headings = detail.headings.map(
+      heading => heading.text ?? heading.key ?? '',
+    )
+    const rows = detail.items.map(item => {
+      if (Array.isArray(item)) return item.map(formatMarkdownValue)
+      if (typeof item === 'object' && item !== null) {
+        const values = item as Record<string, unknown>
+        return (
+          detail.headings?.map(heading =>
+            formatMarkdownValue(values[heading.key ?? '']),
+          ) ?? []
+        )
+      }
+      return [formatMarkdownValue(item)]
+    })
+    return [
+      `| ${headings.join(' | ')} |`,
+      `| ${headings.map(() => '---').join(' | ')} |`,
+      ...rows.map(row => `| ${row.join(' | ')} |`),
+    ].join('\n')
+  }
+
+  if (detail.type === 'list' && detail.items) {
+    return detail.items
+      .map(item => {
+        if (typeof item === 'object' && item !== null && 'text' in item) {
+          return `- ${formatMarkdownValue((item as { text: unknown }).text)}`
+        }
+        return `- ${formatMarkdownValue(item)}`
+      })
+      .join('\n')
+  }
+
+  return `\`\`\`json\n${JSON.stringify(details, null, 2)}\n\`\`\``
+}
+
+function renderBestPractice(
+  bestPractice: BestPracticeAudit,
+  sourceAudits: LH.Result['audits'],
+): string {
+  const { title, displayValue, ...properties } = bestPractice
+  const detail =
+    typeof bestPractice.id === 'string'
+      ? sourceAudits[bestPractice.id]?.details
+      : undefined
+  const lines = [
+    `##### [${bestPractice.status}] ${title ?? ''}`,
+    displayValue === undefined ? '' : String(displayValue),
+    `- status: ${bestPractice.status}`,
+    ...Object.entries(properties)
+      .filter(([key]) => key !== 'status')
+      .map(([key, value]) => `- ${key}: ${formatMarkdownValue(value)}`),
+  ]
+
+  if (detail !== undefined) {
+    lines.push(
+      '<details>',
+      "<summary>Details de l'audit</summary>",
+      '',
+      renderDetails(detail),
+      '',
+      '</details>',
+    )
+  }
+
+  return lines.join('\n')
+}
+
+function renderBestPracticeSection(
+  section: BestPracticeSection,
+  sourceAudits: LH.Result['audits'],
+): string {
+  if (section.bestPractices.length === 0) {
+    return `#### ${section.title}\n\nAucune bonne pratique n'est disponible.`
+  }
+
+  return `#### ${section.title}\n\n${section.bestPractices
+    .map(bestPractice => renderBestPractice(bestPractice, sourceAudits))
+    .join('\n\n')}`
+}
+
+function renderBestPracticesMarkdown(
+  courses: BestPracticesCourseReport[],
+  flows: FlowStep[][],
+): string {
+  const content = courses.map((course, courseIndex) => {
+    const navigationSteps = flows[courseIndex].filter(
+      step => step.lhr.gatherMode === 'navigation',
+    )
+    const pages = course.pages.map((page, pageIndex) => {
+      const sourceAudits = navigationSteps[pageIndex].lhr.audits
+      return [
+        `### Page : ${page.url}`,
+        renderBestPracticeSection(page.rweb, sourceAudits),
+        renderBestPracticeSection(page.bp, sourceAudits),
+      ].join('\n\n')
+    })
+    return `## Parcours : ${course.report}\n\n${pages.join('\n\n')}`
+  })
+
+  return `# Rapport des bonnes pratiques d'ecoconception\n\n${content.join('\n\n')}`
+}
+
+async function printBestPracticesReport(cliFlags: CliFlags): Promise<void> {
+  const jsonFiles = cliFlags['outputFiles']['json']
+  if (!jsonFiles || jsonFiles.length === 0) return
+
+  const courses: BestPracticesCourseReport[] = []
+  const flows: FlowStep[][] = []
+
+  jsonFiles.forEach(jsonFile => {
+    const flow = JSON.parse(fs.readFileSync(jsonFile, 'utf8')) as Flows
+    const navigationSteps = flow.steps.filter(
+      step => step.lhr.gatherMode === 'navigation',
+    )
+    courses.push({
+      report: path.basename(jsonFile),
+      pages: navigationSteps.map(step =>
+        convertBestPracticesPageResults(step.lhr),
+      ),
+    })
+    flows.push(flow.steps)
+  })
+
+  const exportPath = cliFlags['exportPath']
+  writeFileSync(
+    cleanPath(`${exportPath}/best-practices.report.json`),
+    JSON.stringify({ courses }, null, '\t'),
+  )
+  writeFileSync(
+    cleanPath(`${exportPath}/best-practices.report.md`),
+    renderBestPracticesMarkdown(courses, flows),
+  )
+}
+
 /**
  * Generate Summary report from JSON
  * @param {*} cliFlags
@@ -347,6 +513,7 @@ async function printSummary(cliFlags: CliFlags): Promise<void> {
     JSON.stringify(output, null, '\t'),
   )
   console.log(`Summary report generated: ${exportPath}/summary.report.json`)
+  await printBestPracticesReport(cliFlags)
   console.log(`${logSymbols.success} Generating Summary report ended 🎉`)
 }
 

--- a/libs/ecoindex-lh-courses/src/printer.ts
+++ b/libs/ecoindex-lh-courses/src/printer.ts
@@ -300,7 +300,7 @@ function renderDetails(details: unknown): string {
 
   const detail = details as {
     type?: string
-    headings?: Array<{ text?: string; key?: string }>
+    headings?: Array<{ label?: string; text?: string; key?: string }>
     items?: unknown[]
   }
 
@@ -310,7 +310,9 @@ function renderDetails(details: unknown): string {
     detail.items
   ) {
     const headings = detail.headings.map(heading =>
-      escapeMarkdownTableCell(heading.text ?? heading.key ?? ''),
+      escapeMarkdownTableCell(
+        heading.label ?? heading.text ?? heading.key ?? '',
+      ),
     )
     const rows = detail.items.map(item => {
       if (Array.isArray(item)) return item.map(escapeMarkdownTableCell)

--- a/libs/ecoindex-lh-courses/src/printer.ts
+++ b/libs/ecoindex-lh-courses/src/printer.ts
@@ -286,6 +286,13 @@ function formatMarkdownValue(value: unknown): string {
     : String(value)
 }
 
+function escapeMarkdownTableCell(value: unknown): string {
+  return formatMarkdownValue(value)
+    .replaceAll('\\', '\\\\')
+    .replaceAll('|', '\\|')
+    .replace(/\r\n|\r|\n/g, '<br>')
+}
+
 function renderDetails(details: unknown): string {
   if (typeof details !== 'object' || details === null) {
     return `\`\`\`json\n${JSON.stringify(details, null, 2)}\n\`\`\``
@@ -302,20 +309,20 @@ function renderDetails(details: unknown): string {
     detail.headings &&
     detail.items
   ) {
-    const headings = detail.headings.map(
-      heading => heading.text ?? heading.key ?? '',
+    const headings = detail.headings.map(heading =>
+      escapeMarkdownTableCell(heading.text ?? heading.key ?? ''),
     )
     const rows = detail.items.map(item => {
-      if (Array.isArray(item)) return item.map(formatMarkdownValue)
+      if (Array.isArray(item)) return item.map(escapeMarkdownTableCell)
       if (typeof item === 'object' && item !== null) {
         const values = item as Record<string, unknown>
         return (
           detail.headings?.map(heading =>
-            formatMarkdownValue(values[heading.key ?? '']),
+            escapeMarkdownTableCell(values[heading.key ?? '']),
           ) ?? []
         )
       }
-      return [formatMarkdownValue(item)]
+      return [escapeMarkdownTableCell(item)]
     })
     return [
       `| ${headings.join(' | ')} |`,
@@ -427,12 +434,13 @@ async function printBestPracticesReport(cliFlags: CliFlags): Promise<void> {
   })
 
   const exportPath = cliFlags['exportPath']
+  const summaryPath = cleanPath(`${exportPath}/summary`)
   writeFileSync(
-    cleanPath(`${exportPath}/best-practices.report.json`),
+    cleanPath(`${summaryPath}/best-practices.report.json`),
     JSON.stringify({ courses }, null, '\t'),
   )
   writeFileSync(
-    cleanPath(`${exportPath}/best-practices.report.md`),
+    cleanPath(`${summaryPath}/best-practices.report.md`),
     renderBestPracticesMarkdown(courses, flows),
   )
 }
@@ -508,11 +516,13 @@ async function printSummary(cliFlags: CliFlags): Promise<void> {
     output.push(datas)
   })
   const exportPath = cliFlags['exportPath']
+  const summaryPath = cleanPath(`${exportPath}/summary`)
+  fs.mkdirSync(summaryPath, { recursive: true })
   writeFileSync(
-    cleanPath(`${exportPath}/summary.report.json`),
+    cleanPath(`${summaryPath}/report.json`),
     JSON.stringify(output, null, '\t'),
   )
-  console.log(`Summary report generated: ${exportPath}/summary.report.json`)
+  console.log(`Summary report generated: ${summaryPath}/report.json`)
   await printBestPracticesReport(cliFlags)
   console.log(`${logSymbols.success} Generating Summary report ended 🎉`)
 }

--- a/libs/ecoindex-lh-courses/src/printer.ts
+++ b/libs/ecoindex-lh-courses/src/printer.ts
@@ -41,11 +41,7 @@ async function preparareReports(
   // Create the output folder if it doesn't exist.
   const exportPath = cliFlags['exportPath']
 
-  if (course) {
-    await fs.mkdirSync(cleanPath(`${exportPath}/statements`), {
-      recursive: true,
-    })
-  } else {
+  if (!course) {
     await fs.mkdirSync(cleanPath(`${exportPath}`), {
       recursive: true,
     })
@@ -187,6 +183,7 @@ async function printEnvStatementReport(cliFlags: CliFlags, type = 'json-file') {
     }
   }
   // 5. Generate report
+  fs.mkdirSync(dirname(envStatementsObj.statements.json), { recursive: true })
   writeFileSync(
     envStatementsObj.statements.json,
     JSON.stringify(output, null, '\t'),

--- a/libs/ecoindex-lh-courses/src/printer.ts
+++ b/libs/ecoindex-lh-courses/src/printer.ts
@@ -365,7 +365,7 @@ function renderBestPractice(
       .map(([key, value]) => `- ${key}: ${formatMarkdownValue(value)}`),
   ]
 
-  if (detail !== undefined) {
+  if (bestPractice.status === 'KO' && detail !== undefined) {
     lines.push(
       '<details>',
       "<summary>Details de l'audit</summary>",

--- a/libs/ecoindex-lh-courses/src/printer.ts
+++ b/libs/ecoindex-lh-courses/src/printer.ts
@@ -41,10 +41,11 @@ async function preparareReports(
   // Create the output folder if it doesn't exist.
   const exportPath = cliFlags['exportPath']
 
+  await fs.mkdirSync(cleanPath(`${exportPath}`), {
+    recursive: true,
+  })
+
   if (!course) {
-    await fs.mkdirSync(cleanPath(`${exportPath}`), {
-      recursive: true,
-    })
     console.log(
       `${logSymbols.info} With \`url\` option, generic report(s) are generated.`,
     )

--- a/libs/ecoindex-lh-courses/src/printer.ts
+++ b/libs/ecoindex-lh-courses/src/printer.ts
@@ -361,7 +361,7 @@ function renderBestPractice(
     displayValue === undefined ? '' : String(displayValue),
     `- status: ${bestPractice.status}`,
     ...Object.entries(properties)
-      .filter(([key]) => key !== 'status')
+      .filter(([key]) => key !== 'status' && key !== 'score')
       .map(([key, value]) => `- ${key}: ${formatMarkdownValue(value)}`),
   ]
 

--- a/libs/ecoindex-lh-courses/src/run.ts
+++ b/libs/ecoindex-lh-courses/src/run.ts
@@ -394,7 +394,10 @@ async function runCourses(cliFlags: CliFlags) {
     await printEnvStatementReport(cliFlags)
     await printEnvStatementDocuments(cliFlags)
   }
-  if (cliFlags['outputFiles']['json']?.length && cliFlags['url'] === undefined) {
+  if (
+    cliFlags['outputFiles']['json']?.length &&
+    cliFlags['url'] === undefined
+  ) {
     await printSummary(cliFlags)
   }
 }

--- a/libs/ecoindex-lh-courses/src/run.ts
+++ b/libs/ecoindex-lh-courses/src/run.ts
@@ -394,7 +394,7 @@ async function runCourses(cliFlags: CliFlags) {
     await printEnvStatementReport(cliFlags)
     await printEnvStatementDocuments(cliFlags)
   }
-  if (cliFlags['output'].includes('json') && cliFlags['url'] === undefined) {
+  if (cliFlags['outputFiles']['json']?.length && cliFlags['url'] === undefined) {
     await printSummary(cliFlags)
   }
 }

--- a/libs/ecoindex-lh-courses/src/types/index.d.ts
+++ b/libs/ecoindex-lh-courses/src/types/index.d.ts
@@ -160,3 +160,24 @@ export interface SummaryToPrintItem {
   }
   ecoindex: { [key: string]: { score: string; displayValue: string } }
 }
+
+export interface BestPracticeAudit {
+  status: 'OK' | 'KO'
+  [key: string]: unknown
+}
+
+export interface BestPracticeSection {
+  title: string
+  bestPractices: BestPracticeAudit[]
+}
+
+export interface BestPracticesPage {
+  url: string
+  rweb: BestPracticeSection
+  bp: BestPracticeSection
+}
+
+export interface BestPracticesCourseReport {
+  report: string
+  pages: BestPracticesPage[]
+}

--- a/libs/ecoindex-lh-plugin-ts/package.json
+++ b/libs/ecoindex-lh-plugin-ts/package.json
@@ -69,11 +69,11 @@
   },
   "dependencies": {
     "ecoindex": "^2.0.1",
-    "lighthouse": "13.3.0",
+    "lighthouse": "13.4.1",
     "lighthouse-logger": "^2.0.1",
     "lodash.round": "^4.0.4",
     "log-symbols": "4.1.0",
-    "puppeteer-core": "25.1.0"
+    "puppeteer-core": "25.5.0"
   },
   "devDependencies": {
     "@dual-bundle/import-meta-resolve": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^16.0.0
         version: 16.0.0
       lighthouse:
-        specifier: 13.3.0
-        version: 13.3.0
+        specifier: 13.4.1
+        version: 13.4.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(yauzl@2.10.0)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -104,8 +104,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       lighthouse:
-        specifier: 13.3.0
-        version: 13.3.0
+        specifier: 13.4.1
+        version: 13.4.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(yauzl@2.10.0)
       lighthouse-plugin-ecoindex-core:
         specifier: workspace:*
         version: link:../ecoindex-lh-plugin-ts
@@ -113,11 +113,11 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       puppeteer:
-        specifier: 25.1.0
-        version: 25.1.0
+        specifier: 25.5.0
+        version: 25.5.0(yauzl@2.10.0)
       puppeteer-core:
-        specifier: 25.1.0
-        version: 25.1.0
+        specifier: 25.5.0
+        version: 25.5.0(yauzl@2.10.0)
       slugify:
         specifier: ^1.6.6
         version: 1.6.6
@@ -159,8 +159,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       lighthouse:
-        specifier: 13.3.0
-        version: 13.3.0
+        specifier: 13.4.1
+        version: 13.4.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(yauzl@2.10.0)
       lighthouse-logger:
         specifier: ^2.0.1
         version: 2.0.1
@@ -171,8 +171,8 @@ importers:
         specifier: 4.1.0
         version: 4.1.0
       puppeteer-core:
-        specifier: 25.1.0
-        version: 25.1.0
+        specifier: 25.5.0
+        version: 25.5.0(yauzl@2.10.0)
     devDependencies:
       '@dual-bundle/import-meta-resolve':
         specifier: ^4.1.0
@@ -214,8 +214,8 @@ importers:
   test/test-ecoindex-lh-cli:
     dependencies:
       lighthouse:
-        specifier: 13.3.0
-        version: 13.3.0
+        specifier: 13.4.1
+        version: 13.4.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(yauzl@2.10.0)
       lighthouse-plugin-ecoindex:
         specifier: workspace:*
         version: link:../../apps/ecoindex-lh-cli
@@ -226,11 +226,11 @@ importers:
         specifier: workspace:*
         version: link:../../libs/ecoindex-lh-courses
       puppeteer:
-        specifier: 25.1.0
-        version: 25.1.0
+        specifier: 25.5.0
+        version: 25.5.0(yauzl@2.10.0)
       puppeteer-core:
-        specifier: 25.1.0
-        version: 25.1.0
+        specifier: 25.5.0
+        version: 25.5.0(yauzl@2.10.0)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -239,8 +239,8 @@ importers:
   test/test-ecoindex-lh-courses:
     dependencies:
       lighthouse:
-        specifier: 13.3.0
-        version: 13.3.0
+        specifier: 13.4.1
+        version: 13.4.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(yauzl@2.10.0)
       lighthouse-plugin-ecoindex-core:
         specifier: workspace:*
         version: link:../../libs/ecoindex-lh-plugin-ts
@@ -248,11 +248,11 @@ importers:
         specifier: workspace:*
         version: link:../../libs/ecoindex-lh-courses
       puppeteer:
-        specifier: 25.1.0
-        version: 25.1.0
+        specifier: 25.5.0
+        version: 25.5.0(yauzl@2.10.0)
       puppeteer-core:
-        specifier: 25.1.0
-        version: 25.1.0
+        specifier: 25.5.0
+        version: 25.5.0(yauzl@2.10.0)
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -264,8 +264,8 @@ importers:
         specifier: 0.15.1
         version: 0.15.1(encoding@0.1.13)
       lighthouse:
-        specifier: 13.3.0
-        version: 13.3.0
+        specifier: 13.4.1
+        version: 13.4.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(yauzl@2.10.0)
       lighthouse-plugin-ecoindex-core:
         specifier: workspace:*
         version: link:../../libs/ecoindex-lh-plugin-ts
@@ -294,6 +294,17 @@ importers:
         version: 4.21.2
 
 packages:
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
+    resolution: {integrity: sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    resolution: {integrity: sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==}
+    hasBin: true
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
 
   '@aws-crypto/sha256-browser@5.2.0':
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
@@ -1307,6 +1318,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
@@ -1344,12 +1358,16 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api-logs@0.57.2':
     resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
     engines: {node: '>=14'}
 
-  '@opentelemetry/api@1.9.0':
-    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
   '@opentelemetry/context-async-hooks@1.30.1':
@@ -1361,6 +1379,12 @@ packages:
   '@opentelemetry/core@1.30.1':
     resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
     engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
@@ -1496,6 +1520,12 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.7.0
 
+  '@opentelemetry/instrumentation@0.220.0':
+    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
   '@opentelemetry/instrumentation@0.57.2':
     resolution: {integrity: sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==}
     engines: {node: '>=14'}
@@ -1512,11 +1542,29 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
   '@opentelemetry/sdk-trace-base@1.30.1':
     resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
   '@opentelemetry/semantic-conventions@1.28.0':
     resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
@@ -1537,6 +1585,9 @@ packages:
 
   '@paulirish/trace_engine@0.0.64':
     resolution: {integrity: sha512-M1krpfOXJcIQPb6TI6iA+9hHRPv3AxFNHPp/iewzUqbfPL5VnTAqkt6xyqwVGmsuQrko7nV1O3MvLZ3SXfPxbA==}
+
+  '@paulirish/trace_engine@0.0.65':
+    resolution: {integrity: sha512-Qsm6F5C8xf6ZzQXbQc2+wcpe6sggfs/gvc/ytqSurdvYg3kyW0ECHCqE0CWBKZpqgjVfPNX9c7SCS3r2nEIRGg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1598,6 +1649,19 @@ packages:
       proxy-agent: '>=8.0.1'
     peerDependenciesMeta:
       proxy-agent:
+        optional: true
+
+  '@puppeteer/browsers@3.1.0':
+    resolution: {integrity: sha512-RDLpio3fH/qrj5k4DVY6eyiN8tCS0Zovd/6jW//n605oeqkWcUjn+3k+9ZtZBnbwMpsu0F7xDIiKXvVmG5c5Bw==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+    peerDependencies:
+      proxy-agent: '>=8.0.1'
+      yauzl: ^2.10.0 || ^3.4.0
+    peerDependenciesMeta:
+      proxy-agent:
+        optional: true
+      yauzl:
         optional: true
 
   '@rollup/rollup-android-arm-eabi@4.35.0':
@@ -1709,6 +1773,14 @@ packages:
     resolution: {integrity: sha512-Fz5+4XCg3akeoFK+K7g+d7HqGMjmnLoY2eJlpONJmaeT9pXY7yfUyXKZMmMajdE2LxxKJgQ2YKvSCaGVamTjHw==}
     engines: {node: '>=8'}
 
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.70.0':
+    resolution: {integrity: sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==}
+    engines: {node: '>=18'}
+
   '@sentry/core@7.120.4':
     resolution: {integrity: sha512-TXu3Q5kKiq8db9OXGkWyXUbIxMMuttB5vJ031yolOl5T/B69JRyAoKuojLBjRv1XX583gS1rSSoX8YXX7ATFGA==}
     engines: {node: '>=8'}
@@ -1720,6 +1792,27 @@ packages:
   '@sentry/integrations@7.120.4':
     resolution: {integrity: sha512-kkBTLk053XlhDCg7OkBQTIMF4puqFibeRO3E3YiVc4PGLnocXMaVpOSCkMqAc1k1kZ09UgGi8DxfQhnFEjUkpA==}
     engines: {node: '>=8'}
+
+  '@sentry/node-core@10.70.0':
+    resolution: {integrity: sha512-oPOEVVNxv5WHtckx2i06Wi9FLWyvOg/1DUeX732jZ4iqT2nupINaMH4nF4f4kSvUThFnxkFSRQxwqOxgzMKhKA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
 
   '@sentry/node-core@9.46.0':
     resolution: {integrity: sha512-XRVu5pqoklZeh4wqhxCLZkz/ipoKhitctgEFXX9Yh1e1BoHM2pIxT52wf+W6hHM676TFmFXW3uKBjsmRM3AjgA==}
@@ -1733,6 +1826,10 @@ packages:
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.0.0
       '@opentelemetry/semantic-conventions': ^1.34.0
 
+  '@sentry/node@10.70.0':
+    resolution: {integrity: sha512-SPOOVxmKTVIEtqvOKkQT163e/pOwucjS7OPsCHyRs8sFR4nfBNu0EThplyqnvqd5BWBMTPH6WTBQfo+QWHV+HA==}
+    engines: {node: '>=18'}
+
   '@sentry/node@7.120.4':
     resolution: {integrity: sha512-qq3wZAXXj2SRWhqErnGCSJKUhPSlZ+RGnCZjhfjHpP49KNpcd9YdPTIUsFMgeyjdh6Ew6aVCv23g1hTP0CHpYw==}
     engines: {node: '>=8'}
@@ -1740,6 +1837,14 @@ packages:
   '@sentry/node@9.46.0':
     resolution: {integrity: sha512-pRLqAcd7GTGvN8gex5FtkQR5Mcol8gOy1WlyZZFq4rBbVtMbqKOQRhohwqnb+YrnmtFpj7IZ7KNDo077MvNeOQ==}
     engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.70.0':
+    resolution: {integrity: sha512-UNV/2tqypcUK6FDzerAsFJn1Km/c4VZCYkUZDNbnV5S0cwAq2BYKMo4M5vovaLDBQlxA+Wk9ovbxi5wYjjl9fw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
 
   '@sentry/opentelemetry@9.46.0':
     resolution: {integrity: sha512-w2zTxqrdmwRok0cXBoh+ksXdGRUHUZhlpfL/H2kfTodOL+Mk8rW72qUmfqQceXoqgbz8UyK8YgJbyt+XS5H4Qg==}
@@ -1750,6 +1855,10 @@ packages:
       '@opentelemetry/core': ^1.30.1 || ^2.0.0
       '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.0.0
       '@opentelemetry/semantic-conventions': ^1.34.0
+
+  '@sentry/server-utils@10.70.0':
+    resolution: {integrity: sha512-rzegZjMFFgCp3o+N8+XU13rfSvz4B+f8rU0ijBGrQcHdMNyfsFDTu1UTm262JofmrV2u+s+D0u0vFTnqtOGkbA==}
+    engines: {node: '>=18'}
 
   '@sentry/types@7.120.4':
     resolution: {integrity: sha512-cUq2hSSe6/qrU6oZsEP4InMI5VVdD86aypE+ENrQ6eZEVLTCYm1w6XhW1NvIu3UuWh7gZec4a9J7AFpYxki88Q==}
@@ -2330,6 +2439,10 @@ packages:
     resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
     engines: {node: '>=12'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
@@ -2379,6 +2492,10 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -2399,8 +2516,8 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  axe-core@4.11.4:
-    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+  axe-core@4.13.0:
+    resolution: {integrity: sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==}
     engines: {node: '>=4'}
 
   axios-ntlm@1.4.4:
@@ -2583,8 +2700,8 @@ packages:
     peerDependencies:
       devtools-protocol: '*'
 
-  chromium-bidi@16.0.1:
-    resolution: {integrity: sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==}
+  chromium-bidi@17.0.2:
+    resolution: {integrity: sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==}
     engines: {node: '>=20.19.0 <22.0.0 || >=22.12.0'}
     peerDependencies:
       devtools-protocol: '*'
@@ -2595,6 +2712,9 @@ packages:
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   clean-regexp@1.0.0:
     resolution: {integrity: sha512-GfisEZEJvzKrmGWkvfhgzcz/BllN1USeqD2V6tg14OAOgaCD2Z/PUEuxnAZ/nPvmaHRG7a8y77p1T/IRQ4D1Hw==}
@@ -2620,6 +2740,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
 
   clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
@@ -2759,6 +2883,9 @@ packages:
   csp_evaluator@1.1.5:
     resolution: {integrity: sha512-EL/iN9etCTzw/fBnp0/uj0f5BOOGvZut2mzsiiBZ/FdT6gFQCKRO/tmcKOxn5drWZ2Ndm/xBb1SI4zwWbGtmIw==}
 
+  csp_evaluator@1.1.8:
+    resolution: {integrity: sha512-EwOnfYuNbTytvbMKsLixTrRgnjOa0WZCxGy8A9nnSYAicrdwn+T/epU/yjgymmOxlgKnvH+8wXt+7p/8ak5Feg==}
+
   css-select@5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
 
@@ -2864,11 +2991,11 @@ packages:
   devtools-protocol@0.0.1621552:
     resolution: {integrity: sha512-uaHF17cjNtGKOVZUoh8W0PGuEwR3pWzY5kz3sj7PK8N/SyBKG3cPnQIehVDDJkSdph6Omv+GlP7GdM/b4DTgJQ==}
 
-  devtools-protocol@0.0.1624250:
-    resolution: {integrity: sha512-YFAat/lOiIk0ARmBweG+ygrEcbZrq5B9urRyUoeQKp53MlidHXE2TmTbxKcaXoQj7u/aX+jebDO4BW55rs0WwA==}
+  devtools-protocol@0.0.1653615:
+    resolution: {integrity: sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA==}
 
-  devtools-protocol@0.0.1625959:
-    resolution: {integrity: sha512-wRBSU330hwOLLcb3N4NIe3eFs6MgT6ku3AiZONjnTSJ7f3dVchJfn6nE0Lfos9jK1na15bgp7xLhaCx40Y47NQ==}
+  devtools-protocol@0.0.1663043:
+    resolution: {integrity: sha512-33aOY3ZnBP1dgZsshgaL+/XlsQleiFZgyUaDtdZkEa1nbZhVY1MoDeWjk+wxg25fU924l1ZJfoGNmjjeA/5s1w==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -2930,6 +3057,9 @@ packages:
   electron-to-chromium@1.5.123:
     resolution: {integrity: sha512-refir3NlutEZqlKaBLK0tzlVLe5P2wDKS7UQt/3SpibizgsRAPOsqQC3ffw1nlv3ze5gjRQZYHoPymgVZkplFA==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -2986,6 +3116,9 @@ packages:
 
   es-module-lexer@1.6.0:
     resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -3116,6 +3249,10 @@ packages:
 
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
 
   esrecurse@4.3.0:
@@ -3315,6 +3452,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
@@ -3500,6 +3641,10 @@ packages:
 
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
+
+  import-in-the-middle@3.3.3:
+    resolution: {integrity: sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==}
+    engines: {node: '>=18'}
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
@@ -3791,8 +3936,8 @@ packages:
     engines: {node: '>=22.19'}
     hasBin: true
 
-  lighthouse@13.3.0:
-    resolution: {integrity: sha512-jlsJi7+2i2UQWJY8M+gNDEGoDL1sfZ5J2hArCvmQgMTwKq1KQs5ou2pmasyhrRafdU6jh/Prjuz8rZLbqGuydQ==}
+  lighthouse@13.4.1:
+    resolution: {integrity: sha512-fDu8lt3QLK/lTqIxtp1HkzQNJ32rsFHhbadYOepcMZFLgA8oINhxutMbMv8XXnpTOvZ0TXCo4JCk1LDTWaRLnA==}
     engines: {node: '>=22.19'}
     hasBin: true
 
@@ -3913,6 +4058,9 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
@@ -3948,6 +4096,10 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  meriyah@6.1.4:
+    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
+    engines: {node: '>=18.0.0'}
 
   metaviewport-parser@0.3.0:
     resolution: {integrity: sha512-EoYJ8xfjQ6kpe9VbVHvZTZHiOl4HL1Z18CrZ+qahvLXT7ZO4YTC2JMyt5FaUp9JJp6J4Ybb/z7IsCXZt86/QkQ==}
@@ -4435,12 +4587,12 @@ packages:
     resolution: {integrity: sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==}
     engines: {node: '>=18'}
 
-  puppeteer-core@25.1.0:
-    resolution: {integrity: sha512-jKzy5y4WG6uNuFbTWgW1D7mqoT9o0nllc/6a1DGF775T1mPmgw3scdFEtEq67yVFikavQmbYq6NLfbTfxHSlqQ==}
+  puppeteer-core@25.5.0:
+    resolution: {integrity: sha512-XPNT0dQJtphqQ4I29zxlG4IIPbg1iEHAQKWuQgtMJGXjACV77pZSmJvDi51IIIfd+DTKICcopJwUx4upVQ4XbA==}
     engines: {node: '>=22.12.0'}
 
-  puppeteer@25.1.0:
-    resolution: {integrity: sha512-7L6/0JM7XStK99lIL4xQySyNEXNfII6pk0BxkI5kKBTOhR7AsoQiv067YTsE/rIXxQiq9ajlO4WcqBjS/FWK1A==}
+  puppeteer@25.5.0:
+    resolution: {integrity: sha512-qpp73xblxNr+bF0nSXTodM3v+zcK5IPo/GkjLsdUqRf/qpLJp/1KxBUbstoMMnwnPw9xD6OMei8kmYf6CLWfGw==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -4526,6 +4678,10 @@ packages:
     resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
     engines: {node: '>=8.6.0'}
 
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
@@ -4604,6 +4760,9 @@ packages:
 
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+
+  semifies@1.0.0:
+    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -4769,6 +4928,14 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
+
   string_decoder@0.10.31:
     resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==}
 
@@ -4789,6 +4956,10 @@ packages:
 
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
   strip-bom@3.0.0:
@@ -4909,11 +5080,14 @@ packages:
   tldts-core@7.0.30:
     resolution: {integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==}
 
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
   tldts-icann@6.1.84:
     resolution: {integrity: sha512-2e5XqGZRjlNEssjCfftUZSCvoY68KX+eLKRz7oyxUdT0E7YMKyjAZGWL34WqAKcM3y5lLBI3VDclAU+JYw9SlQ==}
 
-  tldts-icann@7.0.30:
-    resolution: {integrity: sha512-o+sKcCCZQOh78GHfpmlcKoef0c+UVfltkqmgKmUHWiMiUhSfer8k5mEkQL2RBqwuC90fluI7ZN50H7+I2bJ1jw==}
+  tldts-icann@7.4.10:
+    resolution: {integrity: sha512-JrzJnTNDURpnyPCf/b0bq/mAiQhPcNwkwpfO67M0nECzVzSIuCFN+EYjqnEjnmO60nPRabS3zIFChbwPp/Q+Lg==}
 
   tldts@7.0.30:
     resolution: {integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==}
@@ -5137,8 +5311,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  web-features@3.26.0:
-    resolution: {integrity: sha512-1qXkBvgi2H1uZ3AmP9GOOF5+LrlO94bJxgh6Kh12yW6wYQQtjXv7ou3ADo3dIuHB98WlHtGp8bjd/w8UQI6tHw==}
+  web-features@3.34.3:
+    resolution: {integrity: sha512-eXdaGO8JSiLLC5/tLOeDiH0EVIbuD8NExMDAziU0frr9JRdiEKqyOsTeEZDtmCXbazEI3mB+plYO4oMYOj1/Dg==}
 
   webdriver-bidi-protocol@0.4.1:
     resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
@@ -5200,6 +5374,10 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -5224,6 +5402,18 @@ packages:
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -5300,6 +5490,10 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
@@ -5311,6 +5505,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yargs@18.1.0:
+    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -5331,6 +5529,30 @@ packages:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
 snapshots:
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      es-module-lexer: 2.3.1
+      magic-string: 0.30.21
+      module-details-from-path: 1.0.4
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    dependencies:
+      '@types/estree': 1.0.9
+      astring: 1.9.0
+      esquery: 1.7.0
+      meriyah: 6.1.4
+      semifies: 1.0.0
+      source-map: 0.6.1
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
@@ -6897,6 +7119,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
@@ -6977,215 +7201,233 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@opentelemetry/api-logs@0.220.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api-logs@0.57.2':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/api@1.9.0': {}
+  '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.28.0
 
-  '@opentelemetry/instrumentation-amqplib@0.46.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.37.0
+
+  '@opentelemetry/instrumentation-amqplib@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-connect@0.43.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-connect@0.43.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
       '@types/connect': 3.4.38
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-dataloader@0.16.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-dataloader@0.16.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-express@0.47.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-express@0.47.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-fs@0.19.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-fs@0.19.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-generic-pool@0.43.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-generic-pool@0.43.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-graphql@0.47.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-graphql@0.47.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-hapi@0.45.2(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-hapi@0.45.2(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-http@0.57.2(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-http@0.57.2(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.28.0
       forwarded-parse: 2.1.2
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-ioredis@0.47.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-ioredis@0.47.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/redis-common': 0.36.2
       '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-kafkajs@0.7.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-kafkajs@0.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-knex@0.44.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-knex@0.44.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-koa@0.47.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-koa@0.47.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-lru-memoizer@0.44.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-lru-memoizer@0.44.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mongodb@0.52.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-mongodb@0.52.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mongoose@0.46.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-mongoose@0.46.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mysql2@0.45.2(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-mysql2@0.45.2(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
-      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-mysql@0.45.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-mysql@0.45.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
       '@types/mysql': 2.15.26
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-pg@0.51.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-pg@0.51.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
-      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.1)
       '@types/pg': 8.6.1
       '@types/pg-pool': 2.0.6
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-redis-4@0.46.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-redis-4@0.46.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/redis-common': 0.36.2
       '@opentelemetry/semantic-conventions': 1.37.0
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-tedious@0.18.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-tedious@0.18.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
       '@types/tedious': 4.0.14
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation-undici@0.10.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation-undici@0.10.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      import-in-the-middle: 3.3.3
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.57.2
       '@types/shimmer': 1.2.0
       import-in-the-middle: 1.15.0
@@ -7197,27 +7439,48 @@ snapshots:
 
   '@opentelemetry/redis-common@0.36.2': {}
 
-  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.28.0
 
-  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.37.0
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.37.0
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.37.0
 
   '@opentelemetry/semantic-conventions@1.28.0': {}
 
   '@opentelemetry/semantic-conventions@1.37.0': {}
 
-  '@opentelemetry/sql-common@0.40.1(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/sql-common@0.40.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
 
   '@paulirish/trace_engine@0.0.53':
     dependencies:
@@ -7229,6 +7492,11 @@ snapshots:
       legacy-javascript: 0.0.1
       third-party-web: 0.29.2
 
+  '@paulirish/trace_engine@0.0.65':
+    dependencies:
+      legacy-javascript: 0.0.1
+      third-party-web: 0.29.2
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -7236,10 +7504,10 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@prisma/instrumentation@6.11.1(@opentelemetry/api@1.9.0)':
+  '@prisma/instrumentation@6.11.1(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7283,6 +7551,13 @@ snapshots:
     dependencies:
       modern-tar: 0.7.6
       yargs: 17.7.2
+
+  '@puppeteer/browsers@3.1.0(yauzl@2.10.0)':
+    dependencies:
+      modern-tar: 0.7.6
+      yargs: 18.1.0
+    optionalDependencies:
+      yauzl: 2.10.0
 
   '@rollup/rollup-android-arm-eabi@4.35.0':
     optional: true
@@ -7347,6 +7622,12 @@ snapshots:
       '@sentry/types': 7.120.4
       '@sentry/utils': 7.120.4
 
+  '@sentry/conventions@0.16.0': {}
+
+  '@sentry/core@10.70.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+
   '@sentry/core@7.120.4':
     dependencies:
       '@sentry/types': 7.120.4
@@ -7361,18 +7642,46 @@ snapshots:
       '@sentry/utils': 7.120.4
       localforage: 1.10.0
 
-  '@sentry/node-core@9.46.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.37.0)':
+  '@sentry/node-core@10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+      '@sentry/opentelemetry': 10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      import-in-the-middle: 3.3.3
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@sentry/node-core@9.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.37.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
       '@sentry/core': 9.46.0
-      '@sentry/opentelemetry': 9.46.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.37.0)
+      '@sentry/opentelemetry': 9.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.37.0)
       import-in-the-middle: 1.15.0
+
+  '@sentry/node@10.70.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+      '@sentry/node-core': 10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.70.0
+      import-in-the-middle: 3.3.3
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
 
   '@sentry/node@7.120.4':
     dependencies:
@@ -7384,52 +7693,70 @@ snapshots:
 
   '@sentry/node@9.46.0':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-amqplib': 0.46.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-connect': 0.43.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-dataloader': 0.16.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-express': 0.47.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-fs': 0.19.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-generic-pool': 0.43.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-graphql': 0.47.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-hapi': 0.45.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-http': 0.57.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-ioredis': 0.47.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-kafkajs': 0.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-knex': 0.44.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-koa': 0.47.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-lru-memoizer': 0.44.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-mongodb': 0.52.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-mongoose': 0.46.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-mysql': 0.45.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-mysql2': 0.45.2(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-pg': 0.51.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-redis-4': 0.46.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-tedious': 0.18.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-undici': 0.10.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-amqplib': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-connect': 0.43.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dataloader': 0.16.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-express': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fs': 0.19.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-generic-pool': 0.43.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-graphql': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-hapi': 0.45.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-ioredis': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-kafkajs': 0.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-knex': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-koa': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongodb': 0.52.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongoose': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql': 0.45.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql2': 0.45.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pg': 0.51.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis-4': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-tedious': 0.18.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici': 0.10.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
-      '@prisma/instrumentation': 6.11.1(@opentelemetry/api@1.9.0)
+      '@prisma/instrumentation': 6.11.1(@opentelemetry/api@1.9.1)
       '@sentry/core': 9.46.0
-      '@sentry/node-core': 9.46.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.37.0)
-      '@sentry/opentelemetry': 9.46.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.37.0)
+      '@sentry/node-core': 9.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.37.0)
+      '@sentry/opentelemetry': 9.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.37.0)
       import-in-the-middle: 1.15.0
       minimatch: 9.0.5
     transitivePeerDependencies:
       - supports-color
 
-  '@sentry/opentelemetry@9.46.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.37.0)':
+  '@sentry/opentelemetry@10.70.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+
+  '@sentry/opentelemetry@9.46.0(@opentelemetry/api@1.9.1)(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.37.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.37.0
       '@sentry/core': 9.46.0
+
+  '@sentry/server-utils@10.70.0':
+    dependencies:
+      '@apm-js-collab/code-transformer-bundler-plugins': 0.7.4
+      '@apm-js-collab/tracing-hooks': 0.13.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.70.0
+      meriyah: 6.1.4
+    transitivePeerDependencies:
+      - supports-color
 
   '@sentry/types@7.120.4': {}
 
@@ -7996,8 +8323,7 @@ snapshots:
 
   '@types/estree@1.0.6': {}
 
-  '@types/estree@1.0.9':
-    optional: true
+  '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -8146,7 +8472,7 @@ snapshots:
       '@usebruno/js': 0.47.0(debug@4.4.3)(encoding@0.1.13)
       '@usebruno/lang': 0.36.0
       '@usebruno/requests': 0.17.0
-      aws4-axios: 3.4.0(axios@1.13.6(debug@4.4.3))
+      aws4-axios: 3.4.0(axios@1.13.6)
       axios: 1.13.6(debug@4.4.3)
       axios-ntlm: 1.4.4(debug@4.4.3)
       chai: 4.5.0
@@ -8319,6 +8645,8 @@ snapshots:
 
   ansi-regex@6.1.0: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@3.2.1:
     dependencies:
       color-convert: 1.9.3
@@ -8357,6 +8685,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  astring@1.9.0: {}
+
   asynckit@0.4.0: {}
 
   atob@2.1.2: {}
@@ -8366,7 +8696,7 @@ snapshots:
       stubborn-fs: 1.2.5
       when-exit: 2.1.4
 
-  aws4-axios@3.4.0(axios@1.13.6(debug@4.4.3)):
+  aws4-axios@3.4.0(axios@1.13.6):
     dependencies:
       '@aws-sdk/client-sts': 3.806.0
       aws4: 1.13.2
@@ -8376,7 +8706,7 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axe-core@4.11.4: {}
+  axe-core@4.13.0: {}
 
   axios-ntlm@1.4.4(debug@4.4.3):
     dependencies:
@@ -8601,15 +8931,17 @@ snapshots:
       mitt: 3.0.1
       zod: 3.24.2
 
-  chromium-bidi@16.0.1(devtools-protocol@0.0.1624250):
+  chromium-bidi@17.0.2(devtools-protocol@0.0.1653615):
     dependencies:
-      devtools-protocol: 0.0.1624250
+      devtools-protocol: 0.0.1653615
       mitt: 3.0.1
       zod: 3.24.2
 
   ci-info@4.2.0: {}
 
   cjs-module-lexer@1.4.3: {}
+
+  cjs-module-lexer@2.2.0: {}
 
   clean-regexp@1.0.0:
     dependencies:
@@ -8644,6 +8976,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   clone-deep@4.0.1:
     dependencies:
@@ -8791,6 +9129,8 @@ snapshots:
 
   csp_evaluator@1.1.5: {}
 
+  csp_evaluator@1.1.8: {}
+
   css-select@5.1.0:
     dependencies:
       boolbase: 1.0.0
@@ -8864,9 +9204,9 @@ snapshots:
 
   devtools-protocol@0.0.1621552: {}
 
-  devtools-protocol@0.0.1624250: {}
+  devtools-protocol@0.0.1653615: {}
 
-  devtools-protocol@0.0.1625959: {}
+  devtools-protocol@0.0.1663043: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -8931,6 +9271,8 @@ snapshots:
 
   electron-to-chromium@1.5.123: {}
 
+  emoji-regex@10.6.0: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -8978,6 +9320,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.6.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -9218,6 +9562,10 @@ snapshots:
   esprima@4.0.1: {}
 
   esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
 
@@ -9466,6 +9814,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.6.0: {}
+
   get-func-name@2.0.2: {}
 
   get-intrinsic@1.3.0:
@@ -9673,6 +10023,12 @@ snapshots:
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
       cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
+
+  import-in-the-middle@3.3.3:
+    dependencies:
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.1
       module-details-from-path: 1.0.4
 
   import-meta-resolve@4.2.0: {}
@@ -9958,7 +10314,7 @@ snapshots:
     dependencies:
       '@paulirish/trace_engine': 0.0.53
       '@sentry/node': 7.120.4
-      axe-core: 4.11.4
+      axe-core: 4.13.0
       chrome-launcher: 1.2.1
       configstore: 5.0.1
       csp_evaluator: 1.1.5
@@ -9994,7 +10350,7 @@ snapshots:
     dependencies:
       '@paulirish/trace_engine': 0.0.64
       '@sentry/node': 9.46.0
-      axe-core: 4.11.4
+      axe-core: 4.13.0
       chrome-launcher: 1.2.1
       configstore: 7.1.0
       csp_evaluator: 1.1.5
@@ -10013,8 +10369,8 @@ snapshots:
       robots-parser: 3.0.1
       speedline-core: 1.4.3
       third-party-web: 0.29.2
-      tldts-icann: 7.0.30
-      web-features: 3.26.0
+      tldts-icann: 7.4.10
+      web-features: 3.34.3
       ws: 7.5.10
       yargs: 17.7.2
       yargs-parser: 21.1.1
@@ -10024,15 +10380,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  lighthouse@13.3.0:
+  lighthouse@13.4.1(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(yauzl@2.10.0):
     dependencies:
-      '@paulirish/trace_engine': 0.0.64
-      '@sentry/node': 9.46.0
-      axe-core: 4.11.4
+      '@paulirish/trace_engine': 0.0.65
+      '@sentry/node': 10.70.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
+      axe-core: 4.13.0
       chrome-launcher: 1.2.1
       configstore: 7.1.0
-      csp_evaluator: 1.1.5
-      devtools-protocol: 0.0.1625959
+      csp_evaluator: 1.1.8
+      devtools-protocol: 0.0.1663043
       enquirer: 2.4.1
       http-link-header: 1.1.3
       intl-messageformat: 10.7.18
@@ -10043,20 +10399,23 @@ snapshots:
       lodash-es: 4.17.21
       lookup-closest-locale: 6.2.0
       open: 8.4.2
-      puppeteer-core: 24.43.1
+      puppeteer-core: 25.5.0(yauzl@2.10.0)
       robots-parser: 3.0.1
       speedline-core: 1.4.3
       third-party-web: 0.29.2
-      tldts-icann: 7.0.30
-      web-features: 3.26.0
+      tldts-icann: 7.4.10
+      web-features: 3.34.3
       ws: 7.5.10
       yargs: 17.7.2
       yargs-parser: 21.1.1
     transitivePeerDependencies:
-      - bare-buffer
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
       - bufferutil
+      - proxy-agent
       - supports-color
       - utf-8-validate
+      - yauzl
 
   lilconfig@3.1.3: {}
 
@@ -10148,6 +10507,10 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   make-dir@2.1.0:
     dependencies:
       pify: 4.0.1
@@ -10172,6 +10535,8 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  meriyah@6.1.4: {}
 
   metaviewport-parser@0.3.0: {}
 
@@ -10597,38 +10962,40 @@ snapshots:
       devtools-protocol: 0.0.1608973
       typed-query-selector: 2.12.2
       webdriver-bidi-protocol: 0.4.1
-      ws: 8.21.0
+      ws: 8.21.3
     transitivePeerDependencies:
       - bare-buffer
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  puppeteer-core@25.1.0:
+  puppeteer-core@25.5.0(yauzl@2.10.0):
     dependencies:
-      '@puppeteer/browsers': 3.0.4
-      chromium-bidi: 16.0.1(devtools-protocol@0.0.1624250)
-      devtools-protocol: 0.0.1624250
+      '@puppeteer/browsers': 3.1.0(yauzl@2.10.0)
+      chromium-bidi: 17.0.2(devtools-protocol@0.0.1653615)
+      devtools-protocol: 0.0.1653615
       typed-query-selector: 2.12.2
       webdriver-bidi-protocol: 0.4.2
-      ws: 8.21.0
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - proxy-agent
       - utf-8-validate
+      - yauzl
 
-  puppeteer@25.1.0:
+  puppeteer@25.5.0(yauzl@2.10.0):
     dependencies:
-      '@puppeteer/browsers': 3.0.4
-      chromium-bidi: 16.0.1(devtools-protocol@0.0.1624250)
-      devtools-protocol: 0.0.1624250
+      '@puppeteer/browsers': 3.1.0(yauzl@2.10.0)
+      chromium-bidi: 17.0.2(devtools-protocol@0.0.1653615)
+      devtools-protocol: 0.0.1653615
       lilconfig: 3.1.3
-      puppeteer-core: 25.1.0
+      puppeteer-core: 25.5.0(yauzl@2.10.0)
       typed-query-selector: 2.12.2
     transitivePeerDependencies:
       - bufferutil
       - proxy-agent
       - utf-8-validate
+      - yauzl
 
   qs@6.13.0:
     dependencies:
@@ -10740,6 +11107,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   require-main-filename@2.0.0: {}
 
   resolve-from@4.0.0: {}
@@ -10824,6 +11198,8 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   sax@1.4.1: {}
+
+  semifies@1.0.0: {}
 
   semver@5.7.2: {}
 
@@ -11010,6 +11386,17 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   string_decoder@0.10.31: {}
 
   string_decoder@1.1.1:
@@ -11031,6 +11418,10 @@ snapshots:
   strip-ansi@7.1.0:
     dependencies:
       ansi-regex: 6.1.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -11147,13 +11538,15 @@ snapshots:
 
   tldts-core@7.0.30: {}
 
+  tldts-core@7.4.10: {}
+
   tldts-icann@6.1.84:
     dependencies:
       tldts-core: 6.1.84
 
-  tldts-icann@7.0.30:
+  tldts-icann@7.4.10:
     dependencies:
-      tldts-core: 7.0.30
+      tldts-core: 7.4.10
 
   tldts@7.0.30:
     dependencies:
@@ -11339,7 +11732,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  web-features@3.26.0: {}
+  web-features@3.34.3: {}
 
   webdriver-bidi-protocol@0.4.1: {}
 
@@ -11398,6 +11791,12 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.0
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2: {}
 
   write-file-atomic@3.0.3:
@@ -11415,6 +11814,8 @@ snapshots:
   ws@7.5.10: {}
 
   ws@8.21.0: {}
+
+  ws@8.21.3: {}
 
   xdg-basedir@4.0.0: {}
 
@@ -11461,6 +11862,8 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
+  yargs-parser@22.0.0: {}
+
   yargs@15.4.1:
     dependencies:
       cliui: 6.0.0
@@ -11494,6 +11897,15 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yargs@18.1.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 8.2.2
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yauzl@2.10.0:
     dependencies:

--- a/test/test-ecoindex-lh-cli/package.json
+++ b/test/test-ecoindex-lh-cli/package.json
@@ -28,12 +28,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "lighthouse": "13.3.0",
+    "lighthouse": "13.4.1",
     "lighthouse-plugin-ecoindex": "workspace:*",
     "lighthouse-plugin-ecoindex-core": "workspace:*",
     "lighthouse-plugin-ecoindex-courses": "workspace:*",
-    "puppeteer": "25.1.0",
-    "puppeteer-core": "25.1.0"
+    "puppeteer": "25.5.0",
+    "puppeteer-core": "25.5.0"
   },
   "devDependencies": {
     "rimraf": "^6.0.1"

--- a/test/test-ecoindex-lh-courses/package.json
+++ b/test/test-ecoindex-lh-courses/package.json
@@ -30,11 +30,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "lighthouse": "13.3.0",
+    "lighthouse": "13.4.1",
     "lighthouse-plugin-ecoindex-core": "workspace:*",
     "lighthouse-plugin-ecoindex-courses": "workspace:*",
-    "puppeteer": "25.1.0",
-    "puppeteer-core": "25.1.0"
+    "puppeteer": "25.5.0",
+    "puppeteer-core": "25.5.0"
   },
   "devDependencies": {
     "rimraf": "^6.0.1"

--- a/test/test-ecoindex-lh-plugin-ts/package.json
+++ b/test/test-ecoindex-lh-plugin-ts/package.json
@@ -23,7 +23,7 @@
   "license": "ISC",
   "dependencies": {
     "@lhci/cli": "0.15.1",
-    "lighthouse": "13.3.0",
+    "lighthouse": "13.4.1",
     "lighthouse-plugin-ecoindex-core": "workspace:*"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Adds aggregate JSON and Markdown reports for RWEB and generic eco-design audits, grouped by course and page. Moves aggregate outputs into the summary directory and prevents empty statements directories for JSON-only runs. Updates related documentation and library dependencies.

## Notable Decisions

Best-practice reports retain binary audit outcomes only (OK / KO), keep RWEB and generic audit sections separate, and expose Lighthouse details only in Markdown for KO audits. Aggregate outputs use the summary directory to avoid collisions with course report names.

## Test Plan

- pnpm build
- pnpm test after the build
- Package lint and strict type checks run for the modified courses package